### PR TITLE
The static files panel shouldn't choke on unexpected data types

### DIFF
--- a/debug_toolbar/panels/staticfiles.py
+++ b/debug_toolbar/panels/staticfiles.py
@@ -21,7 +21,7 @@ class StaticFile:
         self.path = path
 
     def __str__(self):
-        return self.path
+        return str(self.path)
 
     def real_path(self):
         return finders.find(self.path)

--- a/debug_toolbar/panels/staticfiles.py
+++ b/debug_toolbar/panels/staticfiles.py
@@ -17,17 +17,18 @@ class StaticFile:
     Representing the different properties of a static file.
     """
 
-    def __init__(self, path):
+    def __init__(self, *, path, url):
         self.path = path
+        self._url = url
 
     def __str__(self):
-        return str(self.path)
+        return self.path
 
     def real_path(self):
         return finders.find(self.path)
 
     def url(self):
-        return storage.staticfiles_storage.url(self.path)
+        return self._url
 
 
 # This will record and map the StaticFile instances with its associated
@@ -58,6 +59,7 @@ class DebugConfiguredStorage(LazyObject):
 
         class DebugStaticFilesStorage(configured_storage_cls):
             def url(self, path):
+                url = super().url(path)
                 with contextlib.suppress(LookupError):
                     # For LookupError:
                     # The ContextVar wasn't set yet. Since the toolbar wasn't properly
@@ -66,10 +68,10 @@ class DebugConfiguredStorage(LazyObject):
                     request_id = request_id_context_var.get()
                     record_static_file_signal.send(
                         sender=self,
-                        staticfile=StaticFile(path),
+                        staticfile=StaticFile(path=str(path), url=url),
                         request_id=request_id,
                     )
-                return super().url(path)
+                return url
 
         self._wrapped = DebugStaticFilesStorage()
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -6,6 +6,7 @@ Pending
 
 * Added Python 3.13 to the CI matrix.
 * Removed support for Python 3.8 as it has reached end of life.
+* Fixed a crash which occurred when using non-``str`` static file values.
 
 5.0.0-alpha (2024-09-01)
 ------------------------

--- a/tests/panels/test_staticfiles.py
+++ b/tests/panels/test_staticfiles.py
@@ -1,7 +1,9 @@
+from pathlib import Path
+
 from django.conf import settings
 from django.contrib.staticfiles import finders
 from django.shortcuts import render
-from django.test import AsyncRequestFactory
+from django.test import AsyncRequestFactory, RequestFactory
 
 from ..base import BaseTestCase
 
@@ -58,3 +60,19 @@ class StaticFilesPanelTestCase(BaseTestCase):
             "django.contrib.staticfiles.finders.AppDirectoriesFinder", content
         )
         self.assertValidHTML(content)
+
+    def test_path(self):
+        def get_response(request):
+            # template contains one static file
+            return render(
+                request,
+                "staticfiles/path.html",
+                {"path": Path("additional_static/base.css")},
+            )
+
+        self._get_response = get_response
+        request = RequestFactory().get("/")
+        response = self.panel.process_request(request)
+        self.panel.generate_stats(self.request, response)
+        self.assertEqual(self.panel.num_used, 1)
+        self.assertIn('"/static/additional_static/base.css"', self.panel.content)

--- a/tests/templates/staticfiles/path.html
+++ b/tests/templates/staticfiles/path.html
@@ -1,0 +1,1 @@
+{% load static %}{% static path %}


### PR DESCRIPTION
#### Description

Using `Path()` instances in `static()` is unexpected but we shouldn't crash. 

While debugging I found that our `DebugStaticFilesStorage.url` instantiates a `StaticFile` which in turn calls `DebugStaticFilesStorage.url` again, so rendering `self.panel.content` in my test wouldn't end ever. What was tricky about it is that I didn't get an infinite recursion error because we're using a signal. (To be clear: I'm not sure this is what happens, I only think it is.)

I'm confused why this wouldn't have appeared earlier, but I'm happy with the fix.

Fixes #2002 

#### Checklist:

- [x] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.
