### PR TITLE
Update references to point to django-commons repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,5 @@
-[![Jazzband](https://jazzband.co/static/img/jazzband.svg)](https://jazzband.co/)
-
-This is a [Jazzband](https://jazzband.co/) project. By contributing you agree to abide by the [Contributor Code of Conduct](https://jazzband.co/about/conduct) and follow the [guidelines](https://jazzband.co/about/guidelines).
+This is a [Django Commons](https://github.com/django-commons/) project. By contributing you agree to abide by the [Contributor Code of Conduct](https://github.com/django-commons/membership/blob/main/CODE_OF_CONDUCT.md).
 
 Please see the
-[full contributing documentation](https://django-debug-toolbar.readthedocs.io/en/stable/contributing.html)
+[README](https://github.com/django-commons/membership/blob/main/README.md)
 for more help.

--- a/README.rst
+++ b/README.rst
@@ -2,22 +2,18 @@
 Django Debug Toolbar |latest-version|
 =====================================
 
-|jazzband| |build-status| |coverage| |docs| |python-support| |django-support|
+|build-status| |coverage| |docs| |python-support| |django-support|
 
 .. |latest-version| image:: https://img.shields.io/pypi/v/django-debug-toolbar.svg
    :target: https://pypi.org/project/django-debug-toolbar/
    :alt: Latest version on PyPI
 
-.. |jazzband| image:: https://jazzband.co/static/img/badge.svg
-   :target: https://jazzband.co/
-   :alt: Jazzband
-
-.. |build-status| image:: https://github.com/jazzband/django-debug-toolbar/workflows/Test/badge.svg
-   :target: https://github.com/jazzband/django-debug-toolbar/actions
+.. |build-status| image:: https://github.com/django-commons/django-debug-toolbar/workflows/Test/badge.svg
+   :target: https://github.com/django-commons/django-debug-toolbar/actions/workflows/test.yml
    :alt: Build Status
 
 .. |coverage| image:: https://img.shields.io/badge/Coverage-94%25-green
-   :target: https://github.com/jazzband/django-debug-toolbar/actions/workflows/test.yml?query=branch%3Amain
+   :target: https://github.com/django-commons/django-debug-toolbar/actions/workflows/test.yml?query=branch%3Amain
    :alt: Test coverage status
 
 .. |docs| image:: https://img.shields.io/readthedocs/django-debug-toolbar/latest.svg
@@ -38,7 +34,7 @@ more details about the panel's content.
 
 Here's a screenshot of the toolbar in action:
 
-.. image:: https://raw.github.com/jazzband/django-debug-toolbar/main/example/django-debug-toolbar.png
+.. image:: https://raw.github.com/django-commons/django-debug-toolbar/main/example/django-debug-toolbar.png
    :alt: Django Debug Toolbar screenshot
 
 In addition to the built-in panels, a number of third-party panels are
@@ -59,4 +55,4 @@ itself. If you like it, please consider contributing!
 The Django Debug Toolbar was originally created by Rob Hudson <rob@cogit8.org>
 in August 2008 and was further developed by many contributors_.
 
-.. _contributors: https://github.com/jazzband/django-debug-toolbar/graphs/contributors
+.. _contributors: https://github.com/django-commons/django-debug-toolbar/graphs/contributors

--- a/debug_toolbar/panels/sql/panel.py
+++ b/debug_toolbar/panels/sql/panel.py
@@ -89,7 +89,7 @@ def _duplicate_query_key(query):
     raw_params = () if query["raw_params"] is None else tuple(query["raw_params"])
     # repr() avoids problems because of unhashable types
     # (e.g. lists) when used as dictionary keys.
-    # https://github.com/jazzband/django-debug-toolbar/issues/1091
+    # https://github.com/django-commons/django-debug-toolbar/issues/1091
     return (query["raw_sql"], repr(raw_params))
 
 

--- a/debug_toolbar/panels/sql/tracking.py
+++ b/debug_toolbar/panels/sql/tracking.py
@@ -53,8 +53,8 @@ def wrap_cursor(connection):
             # some code in the wild which does not follow that convention,
             # so we pass on the arguments even though it's not clean.
             # See:
-            # https://github.com/jazzband/django-debug-toolbar/pull/615
-            # https://github.com/jazzband/django-debug-toolbar/pull/896
+            # https://github.com/django-commons/django-debug-toolbar/pull/615
+            # https://github.com/django-commons/django-debug-toolbar/pull/896
             logger = connection._djdt_logger
             cursor = connection._djdt_cursor(*args, **kwargs)
             if logger is None:
@@ -66,7 +66,7 @@ def wrap_cursor(connection):
 
         def chunked_cursor(*args, **kwargs):
             # prevent double wrapping
-            # solves https://github.com/jazzband/django-debug-toolbar/issues/1239
+            # solves https://github.com/django-commons/django-debug-toolbar/issues/1239
             logger = connection._djdt_logger
             cursor = connection._djdt_chunked_cursor(*args, **kwargs)
             if logger is not None and not isinstance(cursor, DjDTCursorWrapperMixin):

--- a/debug_toolbar/toolbar.py
+++ b/debug_toolbar/toolbar.py
@@ -110,7 +110,7 @@ class DebugToolbar:
                 # The wsgi.multiprocess case of being True isn't supported until the
                 # toolbar has resolved the following issue:
                 # This type of set up is most likely
-                # https://github.com/jazzband/django-debug-toolbar/issues/1430
+                # https://github.com/django-commons/django-debug-toolbar/issues/1430
                 render_panels = self.request.META.get("wsgi.multiprocess", True)
         return render_panels
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -406,4 +406,4 @@ could add a **debug_toolbar/base.html** template override to your project:
 
 The list of CSS variables are defined at
 `debug_toolbar/static/debug_toolbar/css/toolbar.css
-<https://github.com/jazzband/django-debug-toolbar/blob/main/debug_toolbar/static/debug_toolbar/css/toolbar.css>`_
+<https://github.com/django-commons/django-debug-toolbar/blob/main/debug_toolbar/static/debug_toolbar/css/toolbar.css>`_

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,19 +1,14 @@
 Contributing
 ============
 
-.. image:: https://jazzband.co/static/img/jazzband.svg
-   :target: https://jazzband.co/
-   :alt: Jazzband
-
-This is a `Jazzband <https://jazzband.co>`_ project. By contributing you agree
-to abide by the `Contributor Code of Conduct <https://jazzband.co/about/conduct>`_
-and follow the `guidelines <https://jazzband.co/about/guidelines>`_.
+This is a `Django Commons <https://github.com/django-commons>`_ project. By contributing you agree
+to abide by the `Contributor Code of Conduct <https://github.com/django-commons/membership/blob/main/CODE_OF_CONDUCT.md>`_.
 
 Bug reports and feature requests
 --------------------------------
 
 You can report bugs and request features in the `bug tracker
-<https://github.com/jazzband/django-debug-toolbar/issues>`_.
+<https://github.com/django-commons/django-debug-toolbar/issues>`_.
 
 Please search the existing database for duplicates before filing an issue.
 
@@ -21,13 +16,13 @@ Code
 ----
 
 The code is available `on GitHub
-<https://github.com/jazzband/django-debug-toolbar>`_. Unfortunately, the
+<https://github.com/django-commons/django-debug-toolbar>`_. Unfortunately, the
 repository contains old and flawed objects, so if you have set
 `fetch.fsckObjects
 <https://github.com/git/git/blob/0afbf6caa5b16dcfa3074982e5b48e27d452dbbb/Documentation/config.txt#L1381>`_
 you'll have to deactivate it for this repository::
 
-    git clone --config fetch.fsckobjects=false https://github.com/jazzband/django-debug-toolbar.git
+    git clone --config fetch.fsckobjects=false https://github.com/django-commons/django-debug-toolbar.git
 
 Once you've obtained a checkout, you should create a virtualenv_ and install
 the libraries required for working on the Debug Toolbar::
@@ -145,7 +140,7 @@ Patches
 -------
 
 Please submit `pull requests
-<https://github.com/jazzband/django-debug-toolbar/pulls>`_!
+<https://github.com/django-commons/django-debug-toolbar/pulls>`_!
 
 The Debug Toolbar includes a limited but growing test suite. If you fix a bug
 or add a feature code, please consider adding proper coverage in the test
@@ -176,7 +171,7 @@ You will need to
 `install the Transifex CLI <https://developers.transifex.com/docs/cli>`_.
 
 To publish a release you have to be a `django-debug-toolbar project lead at
-Jazzband <https://jazzband.co/projects/django-debug-toolbar>`__.
+Django Commons <https://github.com/django-commons/django-debug-toolbar>`__.
 
 The release itself requires the following steps:
 
@@ -204,7 +199,7 @@ The release itself requires the following steps:
 
 #. Push the commit and the tag.
 
-#. Publish the release from the Jazzband website.
+#. Publish the release from the Django Commons website.
 
 #. Change the default version of the docs to point to the latest release:
    https://readthedocs.org/dashboard/django-debug-toolbar/versions/

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -31,7 +31,7 @@ instead with the following command:
 
 .. code-block:: console
 
-    $ python -m pip install -e git+https://github.com/jazzband/django-debug-toolbar.git#egg=django-debug-toolbar
+    $ python -m pip install -e git+https://github.com/django-commons/django-debug-toolbar.git#egg=django-debug-toolbar
 
 If you're upgrading from a previous version, you should review the
 :doc:`change log <changes>` and look for specific upgrade instructions.
@@ -84,7 +84,7 @@ Add ``"debug_toolbar"`` to your ``INSTALLED_APPS`` setting:
     ]
 .. note:: Check  out the configuration example in the
    `example app
-   <https://github.com/jazzband/django-debug-toolbar/tree/main/example>`_
+   <https://github.com/django-commons/django-debug-toolbar/tree/main/example>`_
    to learn how to set up the toolbar to function smoothly while running
    your tests.
 

--- a/example/test_views.py
+++ b/example/test_views.py
@@ -1,6 +1,6 @@
 # Add tests to example app to check how the toolbar is used
 # when running tests for a project.
-# See https://github.com/jazzband/django-debug-toolbar/issues/1405
+# See https://github.com/django-commons/django-debug-toolbar/issues/1405
 
 from django.test import TestCase
 from django.urls import reverse

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,18 +40,12 @@ dependencies = [
   "sqlparse>=0.2",
 ]
 urls.Download = "https://pypi.org/project/django-debug-toolbar/"
-urls.Homepage = "https://github.com/jazzband/django-debug-toolbar"
-
-[tool.hatch.build.targets.sdist]
-# Jazzband's release process is limited to 2.2 metadata
-core-metadata-version = "2.2"
+urls.Homepage = "https://github.com/django-commons/django-debug-toolbar"
 
 [tool.hatch.build.targets.wheel]
 packages = [
   "debug_toolbar",
 ]
-# Jazzband's release process is limited to 2.2 metadata
-core-metadata-version = "2.2"
 
 [tool.hatch.version]
 path = "debug_toolbar/__init__.py"

--- a/tests/panels/test_request.py
+++ b/tests/panels/test_request.py
@@ -92,7 +92,7 @@ class RequestPanelTestCase(BaseTestCase):
         """
         Verify that the toolbar doesn't crash if request.POST contains unexpected data.
 
-        See https://github.com/jazzband/django-debug-toolbar/issues/1621
+        See https://github.com/django-commons/django-debug-toolbar/issues/1621
         """
         self.request.POST = [{"a": 1}, {"b": 2}]
         response = self.panel.process_request(self.request)
@@ -112,7 +112,7 @@ class RequestPanelTestCase(BaseTestCase):
         """
         Verify the session is sorted when all keys are strings.
 
-        See  https://github.com/jazzband/django-debug-toolbar/issues/1668
+        See  https://github.com/django-commons/django-debug-toolbar/issues/1668
         """
         self.request.session = {
             1: "value",

--- a/tests/test_integration_async.py
+++ b/tests/test_integration_async.py
@@ -214,7 +214,7 @@ class DebugToolbarTestCase(BaseTestCase):
 # Check out the following links for more information:
 
 # https://forum.djangoproject.com/t/are-concurrent-database-queries-in-asgi-a-thing/24136/2
-# https://github.com/jazzband/django-debug-toolbar/issues/1828
+# https://github.com/django-commons/django-debug-toolbar/issues/1828
 
 # Work that is done so far for asynchrounous database backend
 # https://github.com/django/deps/blob/main/accepted/0009-async.rst#the-orm


### PR DESCRIPTION
#### Description

Hi. I'm not sure if this is planned or I jumped the gun but thought I'd throw this out there.

There's one reference in docs/architecture.rst pointing to the async project board that doesn't exist in the django-commons repo.

If there's a Django Commons image you'd like I can update or feel free to tweak.

