### PR TITLE
Apply UP006 and UP035 changes from pyupgrade pre-commit hook

### DIFF
--- a/debug_toolbar/_stubs.py
+++ b/debug_toolbar/_stubs.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, List, NamedTuple, Optional, Tuple
+from typing import Any, NamedTuple, Optional
 
 from django import template as dj_template
 
@@ -14,7 +14,7 @@ class InspectStack(NamedTuple):
     index: int
 
 
-TidyStackTrace = List[Tuple[str, int, str, str, Optional[Any]]]
+TidyStackTrace = list[tuple[str, int, str, str, Optional[Any]]]
 
 
 class RenderContext(dj_template.context.RenderContext):


### PR DESCRIPTION
UP006: https://docs.astral.sh/ruff/rules/non-pep585-annotation/
UP035: https://docs.astral.sh/ruff/rules/deprecated-import/

#### Description

`pre-commit` output on the main branch wasn't clean. Run `pre-commit run --all-files` and applied the resulting fixes.

The ideal solution here would be to have `pre-commit` running in the CI. I could any recommendations if there is any easy way to achieve that with `tox`
