### PR TITLE
Adopt a basic security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest version of django-debug-toolbar [![PyPI version](https://badge.fury.io/py/django-debug-toolbar.svg)](https://pypi.python.org/pypi/django-debug-toolbar) is supported.
+
+## Reporting a Vulnerability
+
+If you think you have found a vulnerability, and even if you are not sure, please [report it to us in private](https://github.com/django-commons/django-debug-toolbar/security/advisories/new). We will review it and get back to you. Please refrain from public discussions of the issue.


### PR DESCRIPTION
This informs users to submit security reports through GitHub's private vulnerability mechanism.

#### Description

This formalizes a basic security policy for the project. I'm unsure about the supported version aspect. I think it's factual. If there's a bug in an older version that's not in the newer, we're not backporting it. However, we have done this in the past with a significant vulnerability.

#### Checklist:

- [ ] I have added the relevant tests for this change.
- [ ] I have added an item to the Pending section of ``docs/changes.rst``.
