### PR TITLE
Update release workflows to latest trusted publisher GHA.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
         name: python-package-distributions
         path: dist/
     - name: Publish distribution 📦 to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1.10
+      uses: pypa/gh-action-pypi-publish@release/v1.12.3
 
   github-release:
     name: >-
@@ -114,7 +114,7 @@ jobs:
         name: python-package-distributions
         path: dist/
     - name: Publish distribution 📦 to TestPyPI
-      uses: pypa/gh-action-pypi-publish@release/v1.10
+      uses: pypa/gh-action-pypi-publish@release/v1.12.3
       with:
         repository-url: https://test.pypi.org/legacy/
         skip-existing: true


### PR DESCRIPTION
#### Description

Attempt to fix the release part of the build. I think it may be related to https://github.com/pypa/gh-action-pypi-publish/pull/313

#### Checklist:

- [ ] I have added the relevant tests for this change.
- [ ] I have added an item to the Pending section of ``docs/changes.rst``.
