### PR TITLE
Add link to contributing documentation in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,11 @@
+# Contributing to Django Debug Toolbar
+
 This is a [Django Commons](https://github.com/django-commons/) project. By contributing you agree to abide by the [Contributor Code of Conduct](https://github.com/django-commons/membership/blob/main/CODE_OF_CONDUCT.md).
 
-Please see the
-[README](https://github.com/django-commons/membership/blob/main/README.md)
-for more help.
+## Documentation
+
+For detailed contributing guidelines, please see our [Documentation](https://django-debug-toolbar.readthedocs.io/en/latest/contributing.html).
+
+## Additional Resources
+
+Please see the [README](https://github.com/django-commons/membership/blob/main/README.md) for more help.

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -10,6 +10,7 @@ Pending
 * Wrap ``SHOW_TOOLBAR_CALLBACK`` function with ``sync_to_async``
   or ``async_to_sync`` to allow sync/async compatibility.
 * Make ``require_toolbar`` decorator compatible to async views.
+* Added link to contributing documentation in CONTRIBUTING.md to improve contributor onboarding.
 
 5.0.1 (2025-01-13)
 ------------------

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -10,7 +10,7 @@ Pending
 * Wrap ``SHOW_TOOLBAR_CALLBACK`` function with ``sync_to_async``
   or ``async_to_sync`` to allow sync/async compatibility.
 * Make ``require_toolbar`` decorator compatible to async views.
-* Added link to contributing documentation in CONTRIBUTING.md to improve contributor onboarding.
+* Added link to contributing documentation in `CONTRIBUTING.md`.
 
 5.0.1 (2025-01-13)
 ------------------

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -10,7 +10,7 @@ Pending
 * Wrap ``SHOW_TOOLBAR_CALLBACK`` function with ``sync_to_async``
   or ``async_to_sync`` to allow sync/async compatibility.
 * Make ``require_toolbar`` decorator compatible to async views.
-* Added link to contributing documentation in `CONTRIBUTING.md`.
+* Added link to contributing documentation in ``CONTRIBUTING.md``.
 
 5.0.1 (2025-01-13)
 ------------------


### PR DESCRIPTION
#### Description

This PR adds a link to the contributing documentation in CONTRIBUTING.md to make it easier for new contributors to find the complete contribution guidelines. This improves the onboarding experience for new contributors and helps them understand the project's contribution process better.

Fixes #2079 

#### Checklist:

- [ ] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.
