### PR TITLE
Simplify Docker IP determination in middleware.py

### DIFF
--- a/debug_toolbar/middleware.py
+++ b/debug_toolbar/middleware.py
@@ -36,7 +36,7 @@ def show_toolbar(request):
         # This is a hack for docker installations. It attempts to look
         # up the IP address of the docker host.
         # This is not guaranteed to work.
-        docker_ip = docker_ip = socket.gethostbyname('gateway.docker.internal')
+        docker_ip = docker_ip = socket.gethostbyname("gateway.docker.internal")
         if request.META.get("REMOTE_ADDR") == docker_ip:
             return True
     except socket.gaierror:

--- a/debug_toolbar/middleware.py
+++ b/debug_toolbar/middleware.py
@@ -36,7 +36,7 @@ def show_toolbar(request):
         # This is a hack for docker installations. It attempts to look
         # up the IP address of the docker host.
         # This is not guaranteed to work.
-        docker_ip = docker_ip = socket.gethostbyname("gateway.docker.internal")
+        docker_ip = socket.gethostbyname("gateway.docker.internal")
         if request.META.get("REMOTE_ADDR") == docker_ip:
             return True
     except socket.gaierror:

--- a/debug_toolbar/middleware.py
+++ b/debug_toolbar/middleware.py
@@ -36,11 +36,7 @@ def show_toolbar(request):
         # This is a hack for docker installations. It attempts to look
         # up the IP address of the docker host.
         # This is not guaranteed to work.
-        docker_ip = (
-            # Convert the last segment of the IP address to be .1
-            ".".join(socket.gethostbyname("host.docker.internal").rsplit(".")[:-1])
-            + ".1"
-        )
+        docker_ip = docker_ip = socket.gethostbyname('gateway.docker.internal')
         if request.META.get("REMOTE_ADDR") == docker_ip:
             return True
     except socket.gaierror:

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -15,6 +15,7 @@ Pending
 * Added a Makefile target (``make help``) to get a quick overview
   of each target.
 * Avoided reinitializing the staticfiles storage during instrumentation.
+* Simplify Docker IP determination by using gateway IP.
 
 5.0.1 (2025-01-13)
 ------------------

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -67,13 +67,12 @@ class DebugToolbarTestCase(BaseTestCase):
         with self.settings(INTERNAL_IPS=[]):
             self.assertFalse(show_toolbar(self.request))
 
-    @patch("socket.gethostbyname", return_value="127.0.0.255")
+    @patch("socket.gethostbyname", return_value="192.168.65.1")
     def test_show_toolbar_docker(self, mocked_gethostbyname):
         with self.settings(INTERNAL_IPS=[]):
-            # Is true because REMOTE_ADDR is 127.0.0.1 and the 255
-            # is shifted to be 1.
+            self.request.META["REMOTE_ADDR"] = "192.168.65.1"
             self.assertTrue(show_toolbar(self.request))
-        mocked_gethostbyname.assert_called_once_with("host.docker.internal")
+        mocked_gethostbyname.assert_called_once_with("gateway.docker.internal")
 
     def test_not_iterating_over_INTERNAL_IPS(self):
         """Verify that the middleware does not iterate over INTERNAL_IPS in some way.

--- a/tests/test_integration_async.py
+++ b/tests/test_integration_async.py
@@ -54,13 +54,12 @@ class DebugToolbarTestCase(BaseTestCase):
         with self.settings(INTERNAL_IPS=[]):
             self.assertFalse(show_toolbar(self.request))
 
-    @patch("socket.gethostbyname", return_value="127.0.0.255")
+    @patch("socket.gethostbyname", return_value="192.168.65.1")
     async def test_show_toolbar_docker(self, mocked_gethostbyname):
         with self.settings(INTERNAL_IPS=[]):
-            # Is true because REMOTE_ADDR is 127.0.0.1 and the 255
-            # is shifted to be 1.
+            self.request.META["REMOTE_ADDR"] = "192.168.65.1"
             self.assertTrue(show_toolbar(self.request))
-        mocked_gethostbyname.assert_called_once_with("host.docker.internal")
+        mocked_gethostbyname.assert_called_once_with("gateway.docker.internal")
 
     async def test_not_iterating_over_INTERNAL_IPS(self):
         """


### PR DESCRIPTION
#### Description

Updated `show_toolbar` function in `debug_toolbar/middleware.py` to use `gateway.docker.internal` for Docker IP determination per @srus's [comment](https://github.com/django-commons/django-debug-toolbar/issues/1854#issuecomment-2648774317).

To test in a multicontainer, production-ready environment, a [cookiecutter-django](https://github.com/cookiecutter/cookiecutter-django) template configured for Docker was used.

After starting an interactive shell inside the Django container, the commands below were run to compare our current implementation (`host.docker.internal`) to the proposed change to (`gateway.docker.internal`).

```sh
# getent ahostsv4 host.docker.internal
192.168.65.254  STREAM host.docker.internal
192.168.65.254  DGRAM  
192.168.65.254  RAW    
# getent ahostsv4 gateway.docker.internal
192.168.65.1    STREAM gateway.docker.internal
192.168.65.1    DGRAM  
192.168.65.1    RAW   
```

This confirms that since `host.docker.internal` resolves to 192.168.65.254, we don’t need to modify the last octet manually. Instead, we can directly use `gateway.docker.internal`, which already resolves to 192.168.65.1.

The warning in our docs at [installation](https://django-debug-toolbar.readthedocs.io/en/latest/installation.html#configure-internal-ips) is still valid.

Tested on:

- [x] Docker version 27.5.1 + django-debug-toolbar v5.0.1

Keeping as a draft PR until we have tested in at least one more Docker version as well as Podman per @matthiask 's [comment](https://github.com/django-commons/django-debug-toolbar/issues/2076#issue-2843520602).

Fixes #2076

#### Checklist:

- [x] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.
