### PR TITLE
Consolidate csp_nonce usages to a single property on the toolbar.

### DIFF
--- a/debug_toolbar/toolbar.py
+++ b/debug_toolbar/toolbar.py
@@ -74,10 +74,10 @@ class DebugToolbar:
         have a nonce associated with the request. Use the private attribute
         because the lazy object wrapped value can generate a nonce by
         accessing it. This isn't ideal when the toolbar is injecting context
-        into the response because it may set a nonce that is not used with
+        into the response because it may set a nonce not used with
         other assets.
         """
-        return getattr(self.request, "_csp_nonce", None)
+        return getattr(self.request, "csp_nonce", None)
 
     def get_panel_by_id(self, panel_id):
         """

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -11,7 +11,7 @@ Pending
   or ``async_to_sync`` to allow sync/async compatibility.
 * Make ``require_toolbar`` decorator compatible to async views.
 * Added link to contributing documentation in ``CONTRIBUTING.md``.
-* Rely on django-csp's private attribute for nonce, ``request._csp_nonce``.
+* Create a CSP nonce property on the toolbar ``Toolbar().csp_nonce``.
 
 5.0.1 (2025-01-13)
 ------------------

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ deps =
     pygments
     selenium>=4.8.0
     sqlparse
-    django-csp<4
+    django-csp
 passenv=
     CI
     COVERAGE_ARGS


### PR DESCRIPTION

#### Checklist:

- [ ] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.
