### PR TITLE
Add data sanitization to RequestPanel

### DIFF
--- a/debug_toolbar/settings.py
+++ b/debug_toolbar/settings.py
@@ -45,6 +45,17 @@ CONFIG_DEFAULTS = {
     "TOOLBAR_LANGUAGE": None,
     "IS_RUNNING_TESTS": "test" in sys.argv,
     "UPDATE_ON_FETCH": False,
+    "SANITIZE_REQUEST_DATA": True,
+    "REQUEST_SANITIZATION_PATTERNS": (
+        "API",
+        "AUTH",
+        "TOKEN",
+        "KEY",
+        "SECRET",
+        "PASS",
+        "SIGNATURE",
+        "HTTP_COOKIE",
+    ),
     "DEFAULT_THEME": "auto",
 }
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -16,6 +16,7 @@ Pending
   of each target.
 * Avoided reinitializing the staticfiles storage during instrumentation.
 * Fix for exception-unhandled "forked" Promise chain in rebound window.fetch
+* Added optional settings to sanitize sensitive data in the Request panel.
 
 5.0.1 (2025-01-13)
 ------------------

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -385,6 +385,50 @@ Here's what a slightly customized toolbar configuration might look like::
         'SQL_WARNING_THRESHOLD': 100,   # milliseconds
     }
 
+.. _SANITIZE_REQUEST_DATA:
+
+* ``SANITIZE_REQUEST_DATA``
+
+  Default: ``True``
+
+  Panel: request
+
+  This controls whether the toolbar should sanitize the request data
+  before rendering it. This helps prevent sensitive information from
+  being displayed in the Debug Toolbar panels or stored in any
+  persistent storage that might be used.
+
+  This setting sanitizes data in:
+
+  * GET parameters
+  * POST parameters
+  * Cookies
+  * Session data
+
+  Sanitized data is substituted with the string ``"********************"``.
+
+.. _REQUEST_SANITIZATION_PATTERNS:
+
+* ``REQUEST_SANITIZATION_PATTERNS``
+
+  Default::
+
+    (
+        "API",
+        "AUTH",
+        "TOKEN",
+        "KEY",
+        "SECRET",
+        "PASS",
+        "SIGNATURE",
+        "HTTP_COOKIE",
+    )
+
+  Panel: request
+
+  This controls the patterns that the toolbar should use to sanitize
+  the request data.
+
 Theming support
 ---------------
 The debug toolbar uses CSS variables to define fonts and colors. This allows

--- a/tests/panels/test_request.py
+++ b/tests/panels/test_request.py
@@ -165,6 +165,20 @@ class RequestPanelTestCase(BaseTestCase):
         self.assertIn("q", content)
         self.assertIn("search term", content)
 
+    def test_sensitive_cookie_data_sanitization(self):
+        """Test that sensitive cookie data is sanitized."""
+        self.request.COOKIES = {"session_id": "abc123", "auth_token": "xyz789"}
+        response = self.panel.process_request(self.request)
+        self.panel.generate_stats(self.request, response)
+
+        # Check that auth_token is sanitized in panel content
+        content = self.panel.content
+        self.assertIn("session_id", content)
+        self.assertIn("abc123", content)
+        self.assertIn("auth_token", content)
+        self.assertNotIn("xyz789", content)
+        self.assertIn("********************", content)
+
     def test_sensitive_session_data_sanitization(self):
         """Test that sensitive session data is sanitized."""
         self.request.session = {"user_id": 123, "auth_token": "xyz789"}


### PR DESCRIPTION
#### Description

This implementation:

1. Makes sanitization of sensitive values enabled by default but configurable
2. Uses a similar approach to--and the same default key patterns as--Django's sanitization 
3. Allows customizing the patterns used to identify sensitive data

- Added `SANITIZE_REQUEST_DATA` setting to control sanitization of request data.
- Added `REQUEST_SANITIZATION_PATTERNS` setting to define `key` patterns to sanitize the respective `value`.
- Implemented `sanitize_value` function to sanitize sensitive data based on `key` regex patterns.
- Updated `get_sorted_request_variable` to support sanitization.
- Added tests for sanitization of GET and POST parameters, cookies, and session data.
- Updated documentation to include new settings.

Fixes #2074

#### Checklist:

- [x] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.
