### PR TITLE
Fix Dark Mode Conflict in Pygments

### DIFF
--- a/debug_toolbar/static/debug_toolbar/css/toolbar.css
+++ b/debug_toolbar/static/debug_toolbar/css/toolbar.css
@@ -37,7 +37,7 @@
 
 @media (prefers-color-scheme: dark) {
     :root {
-        --djdt-font-color: #8393a7;
+        --djdt-font-color: #f8f8f2;
         --djdt-background-color: #1e293bff;
         --djdt-panel-content-background-color: #0f1729ff;
         --djdt-panel-title-background-color: #242432;

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,7 @@ Change log
 Pending
 -------
 
+* Fix Dark Mode Conflict in Pygments
 * Added Django 5.2 to the tox matrix.
 * Updated package metadata to include well-known labels.
 * Added resources section to the documentation.

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,7 +4,6 @@ Change log
 Pending
 -------
 
-* Fix Dark Mode Conflict in Pygments
 * Added Django 5.2 to the tox matrix.
 * Updated package metadata to include well-known labels.
 * Added resources section to the documentation.
@@ -18,6 +17,7 @@ Pending
 * Avoided reinitializing the staticfiles storage during instrumentation.
 * Avoided a "forked" Promise chain in the rebound ``window.fetch`` function
   with missing exception handling.
+* Fixed the pygments code highlighting when using dark mode.
 
 5.0.1 (2025-01-13)
 ------------------


### PR DESCRIPTION
#### Description

This PR resolves the dark mode conflict with Pygments syntax highlighting in Django Debug Toolbar. The issue was caused by the font color --djdt-font-color: #8393a7;, which made the text less readable.

Fixes #2096 

#### Checklist:

- [X] I have added the relevant tests for this change.
- [X] I have added an item to the Pending section of ``docs/changes.rst``.
