### PR TITLE
Fix #2109: Recursively unwrap loaders to support template partials

### DIFF
--- a/debug_toolbar/panels/templates/views.py
+++ b/debug_toolbar/panels/templates/views.py
@@ -27,15 +27,18 @@ def template_source(request):
     template_name = request.GET.get("template", template_origin_name)
 
     final_loaders = []
-    loaders = Engine.get_default().template_loaders
+    loaders = list(Engine.get_default().template_loaders)
 
-    for loader in loaders:
+    while loaders:
+        loader = loaders.pop(0)
+
         if loader is not None:
-            # When the loader has loaders associated with it,
-            # append those loaders to the list. This occurs with
-            # django.template.loaders.cached.Loader
+            # Recursively unwrap loaders until we get to loaders which do not
+            # themselves wrap other loaders. This occurs
+            # with django.template.loaders.cached.Loader and the
+            # django-template-partials loader (possibly among others)
             if hasattr(loader, "loaders"):
-                final_loaders += loader.loaders
+                loaders.extend(loader.loaders)
             else:
                 final_loaders.append(loader)
 

--- a/debug_toolbar/panels/templates/views.py
+++ b/debug_toolbar/panels/templates/views.py
@@ -34,8 +34,8 @@ def template_source(request):
 
         if loader is not None:
             # Recursively unwrap loaders until we get to loaders which do not
-            # themselves wrap other loaders. This occurs
-            # with django.template.loaders.cached.Loader and the
+            # themselves wrap other loaders. This adds support for
+            # django.template.loaders.cached.Loader and the
             # django-template-partials loader (possibly among others)
             if hasattr(loader, "loaders"):
                 loaders.extend(loader.loaders)

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -7,6 +7,9 @@ Pending
 * Added hook to RedirectsPanel for subclass customization.
 * Added feature to sanitize sensitive data in the Request Panel.
 * Fixed dark mode conflict in code block toolbar CSS
+* Added support for using django-template-partials with the template panel's
+  source view functionality. The same change possibly adds support for other
+  template loaders.
 
 5.1.0 (2025-03-20)
 ------------------

--- a/tests/panels/test_template.py
+++ b/tests/panels/test_template.py
@@ -132,6 +132,24 @@ class TemplatesPanelTestCase(BaseTestCase):
         self.panel.generate_stats(self.request, response)
         self.assertIn("lazy_value", self.panel.content)
 
+    @override_settings(
+        DEBUG=True,
+        DEBUG_TOOLBAR_PANELS=["debug_toolbar.panels.templates.TemplatesPanel"],
+    )
+    def test_template_source(self):
+        from django.core import signing
+        from django.template.loader import get_template
+
+        template = get_template("basic.html")
+        url = "/__debug__/template_source/"
+        data = {
+            "template": template.template.name,
+            "template_origin": signing.dumps(template.template.origin.name),
+        }
+
+        response = self.client.get(url, data)
+        self.assertEqual(response.status_code, 200)
+
 
 @override_settings(
     DEBUG=True, DEBUG_TOOLBAR_PANELS=["debug_toolbar.panels.templates.TemplatesPanel"]

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -28,6 +28,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "debug_toolbar",
+    "template_partials",
     "tests",
 ]
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -28,6 +28,9 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "debug_toolbar",
+    # We are not actively using template-partials; we just want more nesting
+    # in our template loader configuration, see
+    # https://github.com/django-commons/django-debug-toolbar/issues/2109
     "template_partials",
     "tests",
 ]

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -7,6 +7,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
 # Quick-start development settings - unsuitable for production
 
+DEBUG = False
 SECRET_KEY = "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
 
 INTERNAL_IPS = ["127.0.0.1"]

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,7 @@ deps =
     selenium>=4.8.0
     sqlparse
     django-csp
+    django-template-partials
 passenv=
     CI
     COVERAGE_ARGS


### PR DESCRIPTION
#### Description

The current template source view only supports unwrapping one level of 
template loaders depending on other loaders.

When using django-template-partials with cached templates we have to
unwrap the loader twice to get to the concrete loaders.

Fixes #2109

#### Checklist:

- [x] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.
