### PR TITLE
Format the templates using djade

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,11 @@ repos:
     hooks:
     -   id: django-upgrade
         args: [--target-version, "4.2"]
+-   repo: https://github.com/adamchainz/djade-pre-commit
+    rev: "1.3.2"
+    hooks:
+    -   id: djade
+        args: [--target-version, "4.2"]
 -   repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0
     hooks:

--- a/debug_toolbar/templates/debug_toolbar/base.html
+++ b/debug_toolbar/templates/debug_toolbar/base.html
@@ -2,10 +2,10 @@
 {% block css %}
 <link{% if toolbar.csp_nonce %} nonce="{{ toolbar.csp_nonce }}"{% endif %} rel="stylesheet" href="{% static 'debug_toolbar/css/print.css' %}" media="print">
 <link{% if toolbar.csp_nonce %} nonce="{{ toolbar.csp_nonce }}"{% endif %} rel="stylesheet" href="{% static 'debug_toolbar/css/toolbar.css' %}">
-{% endblock %}
+{% endblock css %}
 {% block js %}
 <script{% if toolbar.csp_nonce %} nonce="{{ toolbar.csp_nonce }}"{% endif %} type="module" src="{% static 'debug_toolbar/js/toolbar.js' %}" async></script>
-{% endblock %}
+{% endblock js %}
 <div id="djDebug" class="djdt-hidden" dir="ltr"
      {% if not toolbar.should_render_panels %}
      data-store-id="{{ toolbar.store_id }}"
@@ -19,10 +19,10 @@
      {{ toolbar.config.ROOT_TAG_EXTRA_ATTRS|safe }}  data-update-on-fetch="{{ toolbar.config.UPDATE_ON_FETCH }}">
   <div class="djdt-hidden" id="djDebugToolbar">
     <ul id="djDebugPanelList">
-      <li><a id="djHideToolBarButton" href="#" title="{% trans 'Hide toolbar' %}">{% trans "Hide" %} »</a></li>
+      <li><a id="djHideToolBarButton" href="#" title="{% translate 'Hide toolbar' %}">{% translate "Hide" %} »</a></li>
       <li>
-        <a id="djToggleThemeButton" href="#" title="{% trans 'Toggle Theme' %}">
-          {% trans "Toggle Theme" %} {% include "debug_toolbar/includes/theme_selector.html" %}
+        <a id="djToggleThemeButton" href="#" title="{% translate 'Toggle Theme' %}">
+          {% translate "Toggle Theme" %} {% include "debug_toolbar/includes/theme_selector.html" %}
         </a>
       </li>
       {% for panel in toolbar.panels %}
@@ -31,7 +31,7 @@
     </ul>
   </div>
   <div class="djdt-hidden" id="djDebugToolbarHandle">
-    <div title="{% trans 'Show toolbar' %}" id="djShowToolBarButton">
+    <div title="{% translate 'Show toolbar' %}" id="djShowToolBarButton">
       <span id="djShowToolBarD">D</span><span id="djShowToolBarJ">J</span>DT
     </div>
   </div>

--- a/debug_toolbar/templates/debug_toolbar/includes/panel_button.html
+++ b/debug_toolbar/templates/debug_toolbar/includes/panel_button.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 
 <li id="djdt-{{ panel.panel_id }}" class="djDebugPanelButton">
-  <input type="checkbox" data-cookie="djdt{{ panel.panel_id }}" {% if panel.enabled %}checked title="{% trans "Disable for next and successive requests" %}"{% else %}title="{% trans "Enable for next and successive requests" %}"{% endif %}>
+  <input type="checkbox" data-cookie="djdt{{ panel.panel_id }}" {% if panel.enabled %}checked title="{% translate "Disable for next and successive requests" %}"{% else %}title="{% translate "Enable for next and successive requests" %}"{% endif %}>
   {% if panel.has_content and panel.enabled %}
     <a href="#" title="{{ panel.title }}" class="{{ panel.panel_id }}">
   {% else %}
@@ -9,7 +9,7 @@
   {% endif %}
   {{ panel.nav_title }}
   {% if panel.enabled %}
-    {% with panel.nav_subtitle as subtitle %}
+    {% with subtitle=panel.nav_subtitle %}
       {% if subtitle %}<br><small>{{ subtitle }}</small>{% endif %}
     {% endwith %}
   {% endif %}

--- a/debug_toolbar/templates/debug_toolbar/panels/alerts.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/alerts.html
@@ -1,12 +1,12 @@
 {% load i18n %}
 
 {% if alerts %}
-  <h4>{% trans "Alerts found" %}</h4>
+  <h4>{% translate "Alerts found" %}</h4>
   {% for alert in alerts %}
     <ul>
       <li>{{ alert.alert }}</li>
     </ul>
   {% endfor %}
 {% else %}
-  <h4>{% trans "No alerts found" %}</h4>
+  <h4>{% translate "No alerts found" %}</h4>
 {% endif %}

--- a/debug_toolbar/templates/debug_toolbar/panels/cache.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/cache.html
@@ -1,12 +1,12 @@
 {% load i18n %}
-<h4>{% trans "Summary" %}</h4>
+<h4>{% translate "Summary" %}</h4>
 <table>
   <thead>
     <tr>
-      <th>{% trans "Total calls" %}</th>
-      <th>{% trans "Total time" %}</th>
-      <th>{% trans "Cache hits" %}</th>
-      <th>{% trans "Cache misses" %}</th>
+      <th>{% translate "Total calls" %}</th>
+      <th>{% translate "Total time" %}</th>
+      <th>{% translate "Cache hits" %}</th>
+      <th>{% translate "Cache misses" %}</th>
     </tr>
   </thead>
   <tbody>
@@ -18,7 +18,7 @@
     </tr>
   </tbody>
 </table>
-<h4>{% trans "Commands" %}</h4>
+<h4>{% translate "Commands" %}</h4>
 <table>
   <thead>
     <tr>
@@ -36,15 +36,15 @@
   </tbody>
 </table>
 {% if calls %}
-  <h4>{% trans "Calls" %}</h4>
+  <h4>{% translate "Calls" %}</h4>
   <table>
     <thead>
       <tr>
-        <th colspan="2">{% trans "Time (ms)" %}</th>
-        <th>{% trans "Type" %}</th>
-        <th>{% trans "Arguments" %}</th>
-        <th>{% trans "Keyword arguments" %}</th>
-        <th>{% trans "Backend" %}</th>
+        <th colspan="2">{% translate "Time (ms)" %}</th>
+        <th>{% translate "Type" %}</th>
+        <th>{% translate "Arguments" %}</th>
+        <th>{% translate "Keyword arguments" %}</th>
+        <th>{% translate "Backend" %}</th>
       </tr>
     </thead>
     <tbody>

--- a/debug_toolbar/templates/debug_toolbar/panels/headers.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/headers.html
@@ -1,12 +1,12 @@
 {% load i18n %}
 
-<h4>{% trans "Request headers" %}</h4>
+<h4>{% translate "Request headers" %}</h4>
 
 <table>
   <thead>
     <tr>
-      <th>{% trans "Key" %}</th>
-      <th>{% trans "Value" %}</th>
+      <th>{% translate "Key" %}</th>
+      <th>{% translate "Value" %}</th>
     </tr>
   </thead>
   <tbody>
@@ -19,13 +19,13 @@
   </tbody>
 </table>
 
-<h4>{% trans "Response headers" %}</h4>
+<h4>{% translate "Response headers" %}</h4>
 
 <table>
   <thead>
     <tr>
-      <th>{% trans "Key" %}</th>
-      <th>{% trans "Value" %}</th>
+      <th>{% translate "Key" %}</th>
+      <th>{% translate "Value" %}</th>
     </tr>
   </thead>
   <tbody>
@@ -38,15 +38,15 @@
   </tbody>
 </table>
 
-<h4>{% trans "WSGI environ" %}</h4>
+<h4>{% translate "WSGI environ" %}</h4>
 
-<p>{% trans "Since the WSGI environ inherits the environment of the server, only a significant subset is shown below." %}</p>
+<p>{% translate "Since the WSGI environ inherits the environment of the server, only a significant subset is shown below." %}</p>
 
 <table>
   <thead>
     <tr>
-      <th>{% trans "Key" %}</th>
-      <th>{% trans "Value" %}</th>
+      <th>{% translate "Key" %}</th>
+      <th>{% translate "Value" %}</th>
     </tr>
   </thead>
   <tbody>

--- a/debug_toolbar/templates/debug_toolbar/panels/history.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/history.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% load static %}
+{% load i18n static %}
 <form method="get" action="{% url 'djdt:history_refresh' %}">
     {{ refresh_form.as_div }}
     <button class="refreshHistory">Refresh</button>
@@ -6,12 +6,12 @@
 <table class="djdt-max-height-100">
     <thead>
         <tr>
-            <th>{% trans "Time" %}</th>
-            <th>{% trans "Method" %}</th>
-            <th>{% trans "Path" %}</th>
-            <th>{% trans "Request Variables" %}</th>
-            <th>{% trans "Status" %}</th>
-            <th>{% trans "Action" %}</th>
+            <th>{% translate "Time" %}</th>
+            <th>{% translate "Method" %}</th>
+            <th>{% translate "Path" %}</th>
+            <th>{% translate "Request Variables" %}</th>
+            <th>{% translate "Status" %}</th>
+            <th>{% translate "Action" %}</th>
         </tr>
     </thead>
     <tbody id="djdtHistoryRequests">

--- a/debug_toolbar/templates/debug_toolbar/panels/history_tr.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/history_tr.html
@@ -19,8 +19,8 @@
             </colgroup>
             <thead>
               <tr>
-                <th>{% trans "Variable" %}</th>
-                <th>{% trans "Value" %}</th>
+                <th>{% translate "Variable" %}</th>
+                <th>{% translate "Value" %}</th>
               </tr>
             </thead>
             <tbody>

--- a/debug_toolbar/templates/debug_toolbar/panels/profiling.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/profiling.html
@@ -2,12 +2,12 @@
 <table>
   <thead>
     <tr>
-      <th>{% trans "Call" %}</th>
-      <th>{% trans "CumTime" %}</th>
-      <th>{% trans "Per" %}</th>
-      <th>{% trans "TotTime" %}</th>
-      <th>{% trans "Per" %}</th>
-      <th>{% trans "Count" %}</th>
+      <th>{% translate "Call" %}</th>
+      <th>{% translate "CumTime" %}</th>
+      <th>{% translate "Per" %}</th>
+      <th>{% translate "TotTime" %}</th>
+      <th>{% translate "Per" %}</th>
+      <th>{% translate "Count" %}</th>
     </tr>
   </thead>
   <tbody>

--- a/debug_toolbar/templates/debug_toolbar/panels/request.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/request.html
@@ -1,13 +1,13 @@
 {% load i18n %}
 
-<h4>{% trans "View information" %}</h4>
+<h4>{% translate "View information" %}</h4>
 <table>
   <thead>
     <tr>
-      <th>{% trans "View function" %}</th>
-      <th>{% trans "Arguments" %}</th>
-      <th>{% trans "Keyword arguments" %}</th>
-      <th>{% trans "URL name" %}</th>
+      <th>{% translate "View function" %}</th>
+      <th>{% translate "Arguments" %}</th>
+      <th>{% translate "Keyword arguments" %}</th>
+      <th>{% translate "URL name" %}</th>
     </tr>
   </thead>
   <tbody>
@@ -21,29 +21,29 @@
 </table>
 
 {% if cookies.list or cookies.raw %}
-  <h4>{% trans "Cookies" %}</h4>
+  <h4>{% translate "Cookies" %}</h4>
   {% include 'debug_toolbar/panels/request_variables.html' with variables=cookies %}
 {% else %}
-  <h4>{% trans "No cookies" %}</h4>
+  <h4>{% translate "No cookies" %}</h4>
 {% endif %}
 
 {% if session.list or session.raw %}
-  <h4>{% trans "Session data" %}</h4>
+  <h4>{% translate "Session data" %}</h4>
   {% include 'debug_toolbar/panels/request_variables.html' with variables=session %}
 {% else %}
-  <h4>{% trans "No session data" %}</h4>
+  <h4>{% translate "No session data" %}</h4>
 {% endif %}
 
 {% if get.list or get.raw %}
-  <h4>{% trans "GET data" %}</h4>
+  <h4>{% translate "GET data" %}</h4>
   {% include 'debug_toolbar/panels/request_variables.html' with variables=get %}
 {% else %}
-  <h4>{% trans "No GET data" %}</h4>
+  <h4>{% translate "No GET data" %}</h4>
 {% endif %}
 
 {% if post.list or post.raw %}
-  <h4>{% trans "POST data" %}</h4>
+  <h4>{% translate "POST data" %}</h4>
   {% include 'debug_toolbar/panels/request_variables.html' with variables=post %}
 {% else %}
-  <h4>{% trans "No POST data" %}</h4>
+  <h4>{% translate "No POST data" %}</h4>
 {% endif %}

--- a/debug_toolbar/templates/debug_toolbar/panels/request_variables.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/request_variables.html
@@ -8,8 +8,8 @@
   </colgroup>
   <thead>
     <tr>
-      <th>{% trans "Variable" %}</th>
-      <th>{% trans "Value" %}</th>
+      <th>{% translate "Variable" %}</th>
+      <th>{% translate "Value" %}</th>
     </tr>
   </thead>
   <tbody>

--- a/debug_toolbar/templates/debug_toolbar/panels/settings.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/settings.html
@@ -2,8 +2,8 @@
 <table>
   <thead>
     <tr>
-      <th>{% trans "Setting" %}</th>
-      <th>{% trans "Value" %}</th>
+      <th>{% translate "Setting" %}</th>
+      <th>{% translate "Value" %}</th>
     </tr>
   </thead>
   <tbody>

--- a/debug_toolbar/templates/debug_toolbar/panels/signals.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/signals.html
@@ -2,8 +2,8 @@
 <table>
   <thead>
     <tr>
-      <th>{% trans "Signal" %}</th>
-      <th>{% trans "Receivers" %}</th>
+      <th>{% translate "Signal" %}</th>
+      <th>{% translate "Receivers" %}</th>
     </tr>
   </thead>
   <tbody>

--- a/debug_toolbar/templates/debug_toolbar/panels/sql.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/sql.html
@@ -3,15 +3,15 @@
   {% for alias, info in databases %}
     <li>
       <strong><span class="djdt-color" data-djdt-styles="backgroundColor:rgb({{ info.rgb_color|join:', ' }})"></span> {{ alias }}</strong>
-      {{ info.time_spent|floatformat:"2" }} ms ({% blocktrans count info.num_queries as num %}{{ num }} query{% plural %}{{ num }} queries{% endblocktrans %}
+      {{ info.time_spent|floatformat:"2" }} ms ({% blocktranslate count num=info.num_queries %}{{ num }} query{% plural %}{{ num }} queries{% endblocktranslate %}
       {% if info.similar_count %}
-        {% blocktrans with count=info.similar_count trimmed %}
+        {% blocktranslate with count=info.similar_count trimmed %}
           including <abbr title="Similar queries are queries with the same SQL, but potentially different parameters.">{{ count }} similar</abbr>
-        {% endblocktrans %}
+        {% endblocktranslate %}
         {% if info.duplicate_count %}
-          {% blocktrans with dupes=info.duplicate_count trimmed %}
+          {% blocktranslate with dupes=info.duplicate_count trimmed %}
             and <abbr title="Duplicate queries are identical to each other: they execute exactly the same SQL and parameters.">{{ dupes }} duplicates</abbr>
-          {% endblocktrans %}
+          {% endblocktranslate %}
         {% endif %}
       {% endif %})
     </li>
@@ -31,16 +31,16 @@
     <thead>
       <tr>
         <th></th>
-        <th colspan="2">{% trans "Query" %}</th>
-        <th>{% trans "Timeline" %}</th>
-        <th>{% trans "Time (ms)" %}</th>
-        <th>{% trans "Action" %}</th>
+        <th colspan="2">{% translate "Query" %}</th>
+        <th>{% translate "Timeline" %}</th>
+        <th>{% translate "Time (ms)" %}</th>
+        <th>{% translate "Action" %}</th>
       </tr>
     </thead>
     <tbody>
       {% for query in queries %}
         <tr class="{% if query.is_slow %} djDebugRowWarning{% endif %}" id="sqlMain_{{ forloop.counter }}">
-          <td><span class="djdt-color" data-djdt-styles="backgroundColor:rgb({{ query.rgb_color|join:', '}})"></span></td>
+          <td><span class="djdt-color" data-djdt-styles="backgroundColor:rgb({{ query.rgb_color|join:', ' }})"></span></td>
           <td class="djdt-toggle">
             <button type="button" class="djToggleSwitch" data-toggle-name="sqlMain" data-toggle-id="{{ forloop.counter }}">+</button>
           </td>
@@ -49,13 +49,13 @@
             {% if query.similar_count %}
               <strong>
                 <span class="djdt-color" data-djdt-styles="backgroundColor:{{ query.similar_color }}"></span>
-                {% blocktrans with count=query.similar_count %}{{ count }} similar queries.{% endblocktrans %}
+                {% blocktranslate with count=query.similar_count %}{{ count }} similar queries.{% endblocktranslate %}
               </strong>
             {% endif %}
             {% if query.duplicate_count %}
               <strong>
                 <span class="djdt-color" data-djdt-styles="backgroundColor:{{ query.duplicate_color }}"></span>
-                {% blocktrans with dupes=query.duplicate_count %}Duplicated {{ dupes }} times.{% endblocktrans %}
+                {% blocktranslate with dupes=query.duplicate_count %}Duplicated {{ dupes }} times.{% endblocktranslate %}
               </strong>
             {% endif %}
           </td>
@@ -92,12 +92,12 @@
           <td colspan="2"></td>
           <td colspan="4">
             <div class="djSQLDetailsDiv">
-              <p><strong>{% trans "Connection:" %}</strong> {{ query.alias }}</p>
+              <p><strong>{% translate "Connection:" %}</strong> {{ query.alias }}</p>
               {% if query.iso_level %}
-                <p><strong>{% trans "Isolation level:" %}</strong> {{ query.iso_level }}</p>
+                <p><strong>{% translate "Isolation level:" %}</strong> {{ query.iso_level }}</p>
               {% endif %}
               {% if query.trans_status %}
-                <p><strong>{% trans "Transaction status:" %}</strong> {{ query.trans_status }}</p>
+                <p><strong>{% translate "Transaction status:" %}</strong> {{ query.trans_status }}</p>
               {% endif %}
               {% if query.stacktrace %}
                 <pre class="djdt-stack">{{ query.stacktrace }}</pre>
@@ -120,5 +120,5 @@
     </tbody>
   </table>
 {% else %}
-  <p>{% trans "No SQL queries were recorded during this request." %}</p>
+  <p>{% translate "No SQL queries were recorded during this request." %}</p>
 {% endif %}

--- a/debug_toolbar/templates/debug_toolbar/panels/sql_explain.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/sql_explain.html
@@ -1,16 +1,16 @@
 {% load i18n %}
 <div class="djDebugPanelTitle">
   <button type="button" class="djDebugClose">»</button>
-  <h3>{% trans "SQL explained" %}</h3>
+  <h3>{% translate "SQL explained" %}</h3>
 </div>
 <div class="djDebugPanelContent">
   <div class="djdt-scroll">
     <dl>
-      <dt>{% trans "Executed SQL" %}</dt>
+      <dt>{% translate "Executed SQL" %}</dt>
       <dd>{{ sql|safe }}</dd>
-      <dt>{% trans "Time" %}</dt>
+      <dt>{% translate "Time" %}</dt>
       <dd>{{ duration }} ms</dd>
-      <dt>{% trans "Database" %}</dt>
+      <dt>{% translate "Database" %}</dt>
       <dd>{{ alias }}</dd>
     </dl>
     <table>

--- a/debug_toolbar/templates/debug_toolbar/panels/sql_profile.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/sql_profile.html
@@ -1,17 +1,17 @@
 {% load i18n %}
 <div class="djDebugPanelTitle">
   <button type="button" class="djDebugClose">»</button>
-  <h3>{% trans "SQL profiled" %}</h3>
+  <h3>{% translate "SQL profiled" %}</h3>
 </div>
 <div class="djDebugPanelContent">
   <div class="djdt-scroll">
     {% if result %}
       <dl>
-        <dt>{% trans "Executed SQL" %}</dt>
+        <dt>{% translate "Executed SQL" %}</dt>
         <dd>{{ sql|safe }}</dd>
-        <dt>{% trans "Time" %}</dt>
+        <dt>{% translate "Time" %}</dt>
         <dd>{{ duration }} ms</dd>
-        <dt>{% trans "Database" %}</dt>
+        <dt>{% translate "Database" %}</dt>
         <dd>{{ alias }}</dd>
       </dl>
       <table>
@@ -34,7 +34,7 @@
       </table>
     {% else %}
       <dl>
-        <dt>{% trans "Error" %}</dt>
+        <dt>{% translate "Error" %}</dt>
         <dd>{{ result_error }}</dd>
       </dl>
     {% endif %}

--- a/debug_toolbar/templates/debug_toolbar/panels/sql_select.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/sql_select.html
@@ -1,16 +1,16 @@
 {% load i18n %}
 <div class="djDebugPanelTitle">
   <button type="button" class="djDebugClose">»</button>
-  <h3>{% trans "SQL selected" %}</h3>
+  <h3>{% translate "SQL selected" %}</h3>
 </div>
 <div class="djDebugPanelContent">
   <div class="djdt-scroll">
     <dl>
-      <dt>{% trans "Executed SQL" %}</dt>
+      <dt>{% translate "Executed SQL" %}</dt>
       <dd>{{ sql|safe }}</dd>
-      <dt>{% trans "Time" %}</dt>
+      <dt>{% translate "Time" %}</dt>
       <dd>{{ duration }} ms</dd>
-      <dt>{% trans "Database" %}</dt>
+      <dt>{% translate "Database" %}</dt>
       <dd>{{ alias }}</dd>
     </dl>
     {% if result %}
@@ -33,7 +33,7 @@
         </tbody>
       </table>
     {% else %}
-      <p>{% trans "Empty set" %}</p>
+      <p>{% translate "Empty set" %}</p>
     {% endif %}
   </div>
 </div>

--- a/debug_toolbar/templates/debug_toolbar/panels/staticfiles.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/staticfiles.html
@@ -1,17 +1,17 @@
 {% load i18n %}
 
-<h4>{% blocktrans count staticfiles_dirs|length as dirs_count %}Static file path{% plural %}Static file paths{% endblocktrans %}</h4>
+<h4>{% blocktranslate count dirs_count=staticfiles_dirs|length %}Static file path{% plural %}Static file paths{% endblocktranslate %}</h4>
 {% if staticfiles_dirs %}
   <ol>
     {% for prefix, staticfiles_dir in staticfiles_dirs %}
-      <li>{{ staticfiles_dir }}{% if prefix %} {% blocktrans %}(prefix {{ prefix }}){% endblocktrans %}{% endif %}</li>
+      <li>{{ staticfiles_dir }}{% if prefix %} {% blocktranslate %}(prefix {{ prefix }}){% endblocktranslate %}{% endif %}</li>
     {% endfor %}
   </ol>
 {% else %}
-  <p>{% trans "None" %}</p>
+  <p>{% translate "None" %}</p>
 {% endif %}
 
-<h4>{% blocktrans count staticfiles_apps|length as apps_count %}Static file app{% plural %}Static file apps{% endblocktrans %}</h4>
+<h4>{% blocktranslate count apps_count=staticfiles_apps|length %}Static file app{% plural %}Static file apps{% endblocktranslate %}</h4>
 {% if staticfiles_apps %}
   <ol>
     {% for static_app in staticfiles_apps %}
@@ -19,10 +19,10 @@
     {% endfor %}
   </ol>
 {% else %}
-  <p>{% trans "None" %}</p>
+  <p>{% translate "None" %}</p>
 {% endif %}
 
-<h4>{% blocktrans count staticfiles|length as staticfiles_count %}Static file{% plural %}Static files{% endblocktrans %}</h4>
+<h4>{% blocktranslate count staticfiles_count=staticfiles|length %}Static file{% plural %}Static files{% endblocktranslate %}</h4>
 {% if staticfiles %}
   <dl>
     {% for staticfile in staticfiles %}
@@ -31,17 +31,17 @@
     {% endfor %}
   </dl>
 {% else %}
-  <p>{% trans "None" %}</p>
+  <p>{% translate "None" %}</p>
 {% endif %}
 
 
 {% for finder, payload in staticfiles_finders.items %}
-  <h4>{{ finder }} ({% blocktrans count payload|length as payload_count %}{{ payload_count }} file{% plural %}{{ payload_count }} files{% endblocktrans %})</h4>
+  <h4>{{ finder }} ({% blocktranslate count payload_count=payload|length %}{{ payload_count }} file{% plural %}{{ payload_count }} files{% endblocktranslate %})</h4>
   <table>
     <thead>
       <tr>
-        <th>{% trans 'Path' %}</th>
-        <th>{% trans 'Location' %}</th>
+        <th>{% translate 'Path' %}</th>
+        <th>{% translate 'Location' %}</th>
       </tr>
     </thead>
     <tbody>

--- a/debug_toolbar/templates/debug_toolbar/panels/template_source.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/template_source.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 <div class="djDebugPanelTitle">
   <button type="button" class="djDebugClose">»</button>
-  <h3>{% trans "Template source:" %} <code>{{ template_name }}</code></h3>
+  <h3>{% translate "Template source:" %} <code>{{ template_name }}</code></h3>
 </div>
 <div class="djDebugPanelContent">
   <div class="djdt-scroll">

--- a/debug_toolbar/templates/debug_toolbar/panels/templates.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/templates.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<h4>{% blocktrans count template_dirs|length as template_count %}Template path{% plural %}Template paths{% endblocktrans %}</h4>
+<h4>{% blocktranslate count template_count=template_dirs|length %}Template path{% plural %}Template paths{% endblocktranslate %}</h4>
 {% if template_dirs %}
   <ol>
     {% for template in template_dirs %}
@@ -7,10 +7,10 @@
     {% endfor %}
   </ol>
 {% else %}
-  <p>{% trans "None" %}</p>
+  <p>{% translate "None" %}</p>
 {% endif %}
 
-<h4>{% blocktrans count templates|length as template_count %}Template{% plural %}Templates{% endblocktrans %}</h4>
+<h4>{% blocktranslate count template_count=templates|length %}Template{% plural %}Templates{% endblocktranslate %}</h4>
 {% if templates %}
   <dl>
     {% for template in templates %}
@@ -19,7 +19,7 @@
       {% if template.context %}
         <dd>
           <details>
-            <summary>{% trans "Toggle context" %}</summary>
+            <summary>{% translate "Toggle context" %}</summary>
             <code class="djTemplateContext">{{ template.context }}</code>
           </details>
         </dd>
@@ -27,22 +27,22 @@
     {% endfor %}
   </dl>
 {% else %}
-  <p>{% trans "None" %}</p>
+  <p>{% translate "None" %}</p>
 {% endif %}
 
-<h4>{% blocktrans count context_processors|length as context_processors_count %}Context processor{% plural %}Context processors{% endblocktrans %}</h4>
+<h4>{% blocktranslate count context_processors_count=context_processors|length %}Context processor{% plural %}Context processors{% endblocktranslate %}</h4>
 {% if context_processors %}
   <dl>
     {% for key, value in context_processors.items %}
       <dt><strong>{{ key|escape }}</strong></dt>
       <dd>
         <details>
-          <summary>{% trans "Toggle context" %}</summary>
+          <summary>{% translate "Toggle context" %}</summary>
           <code class="djTemplateContext">{{ value|escape }}</code>
         </details>
       </dd>
     {% endfor %}
   </dl>
 {% else %}
-  <p>{% trans "None" %}</p>
+  <p>{% translate "None" %}</p>
 {% endif %}

--- a/debug_toolbar/templates/debug_toolbar/panels/timer.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/timer.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<h4>{% trans "Resource usage" %}</h4>
+<h4>{% translate "Resource usage" %}</h4>
 <table>
   <colgroup>
     <col class="djdt-width-20">
@@ -7,8 +7,8 @@
   </colgroup>
   <thead>
     <tr>
-      <th>{% trans "Resource" %}</th>
-      <th>{% trans "Value" %}</th>
+      <th>{% translate "Resource" %}</th>
+      <th>{% translate "Value" %}</th>
     </tr>
   </thead>
   <tbody>
@@ -23,7 +23,7 @@
 
 <!-- This hidden div is populated and displayed by code in toolbar.timer.js -->
 <div id="djDebugBrowserTiming" class="djdt-hidden">
-  <h4>{% trans "Browser timing" %}</h4>
+  <h4>{% translate "Browser timing" %}</h4>
   <table>
     <colgroup>
       <col class="djdt-width-20">
@@ -32,9 +32,9 @@
     </colgroup>
     <thead>
       <tr>
-        <th>{% trans "Timing attribute" %}</th>
-        <th>{% trans "Timeline" %}</th>
-        <th>{% trans "Milliseconds since navigation start (+length)" %}</th>
+        <th>{% translate "Timing attribute" %}</th>
+        <th>{% translate "Timeline" %}</th>
+        <th>{% translate "Milliseconds since navigation start (+length)" %}</th>
       </tr>
     </thead>
     <tbody id="djDebugBrowserTimingTableBody">

--- a/debug_toolbar/templates/debug_toolbar/panels/versions.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/versions.html
@@ -7,9 +7,9 @@
   </colgroup>
   <thead>
     <tr>
-      <th>{% trans "Package" %}</th>
-      <th>{% trans "Name" %}</th>
-      <th>{% trans "Version" %}</th>
+      <th>{% translate "Package" %}</th>
+      <th>{% translate "Name" %}</th>
+      <th>{% translate "Version" %}</th>
     </tr>
   </thead>
   <tbody>

--- a/debug_toolbar/templates/debug_toolbar/redirect.html
+++ b/debug_toolbar/templates/debug_toolbar/redirect.html
@@ -7,9 +7,9 @@
   </head>
   <body>
     <h1>{{ status_line }}</h1>
-    <h2>{% trans "Location:" %} <a id="redirect_to" href="{{ redirect_to }}">{{ redirect_to }}</a></h2>
+    <h2>{% translate "Location:" %} <a id="redirect_to" href="{{ redirect_to }}">{{ redirect_to }}</a></h2>
     <p class="notice">
-      {% trans "The Django Debug Toolbar has intercepted a redirect to the above URL for debug viewing purposes. You can click the above link to continue with the redirect as normal." %}
+      {% translate "The Django Debug Toolbar has intercepted a redirect to the above URL for debug viewing purposes. You can click the above link to continue with the redirect as normal." %}
     </p>
   </body>
 </html>

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -13,6 +13,8 @@ Pending
 * Added support for using django-template-partials with the template panel's
   source view functionality. The same change possibly adds support for other
   template loaders.
+* Introduced `djade <https://github.com/adamchainz/djade>`__ to format Django
+  templates.
 
 5.1.0 (2025-03-20)
 ------------------

--- a/example/templates/htmx/boost.html
+++ b/example/templates/htmx/boost.html
@@ -7,7 +7,7 @@
     <script src="//unpkg.com/htmx.org@1.8.4"></script>
   </head>
   <body hx-boost="true">
-    <h1>Index of Tests (htmx) - Page {{page_num|default:"1"}}</h1>
+    <h1>Index of Tests (htmx) - Page {{ page_num|default:"1" }}</h1>
 
     <p>
       For the debug panel to remain through page navigation, add the setting:

--- a/example/templates/turbo/index.html
+++ b/example/templates/turbo/index.html
@@ -7,7 +7,7 @@
     <script src="//unpkg.com/@hotwired/turbo@7.2.4"></script>
   </head>
   <body>
-    <h1>Turbo Index - Page {{page_num|default:"1"}}</h1>
+    <h1>Turbo Index - Page {{ page_num|default:"1" }}</h1>
 
     <p>
       For the debug panel to remain through page navigation, add the setting:

--- a/tests/panels/test_sql.py
+++ b/tests/panels/test_sql.py
@@ -655,8 +655,8 @@ class SQLPanelTestCase(BaseTestCase):
         template_info = query["template_info"]
         template_name = os.path.basename(template_info["name"])
         self.assertEqual(template_name, "flat.html")
-        self.assertEqual(template_info["context"][2]["content"].strip(), "{{ users }}")
-        self.assertEqual(template_info["context"][2]["highlight"], True)
+        self.assertEqual(template_info["context"][3]["content"].strip(), "{{ users }}")
+        self.assertEqual(template_info["context"][3]["highlight"], True)
 
     @override_settings(
         DEBUG=True,

--- a/tests/templates/ajax/ajax.html
+++ b/tests/templates/ajax/ajax.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+
 {% block content %}
   <div id="click_for_ajax">click for ajax</div>
 
@@ -18,4 +19,4 @@
   }
   document.addEventListener("click", (event) => {send_ajax()});
   </script>
-{% endblock %}
+{% endblock content %}

--- a/tests/templates/basic.html
+++ b/tests/templates/basic.html
@@ -1,2 +1,3 @@
 {% extends "base.html" %}
+
 {% block content %}Test for {{ title }}{% endblock %}

--- a/tests/templates/jinja2/basic.jinja
+++ b/tests/templates/jinja2/basic.jinja
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
+
 {% block content %}
 Test for {{ title }} (Jinja)
 {% for i in range(10) %}{{ i }}{% endfor %} {# Jinja2 supports range(), Django templates do not #}
-{% endblock %}
+{% endblock content %}

--- a/tests/templates/sql/flat.html
+++ b/tests/templates/sql/flat.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+
 {% block content %}
   {{ users }}
-{% endblock %}
+{% endblock content %}

--- a/tests/templates/sql/nested.html
+++ b/tests/templates/sql/nested.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+
 {% block content %}
   {% include "sql/included.html" %}
-{% endblock %}
+{% endblock content %}

--- a/tests/templates/staticfiles/async_static.html
+++ b/tests/templates/staticfiles/async_static.html
@@ -3,4 +3,4 @@
 
 {% block head %}
     <link rel="stylesheet" href="{% static 'additional_static/base.css' %}">
-{% endblock %}
+{% endblock head %}


### PR DESCRIPTION
#### Description

The djade template formatter standardizes `load` tags, translation tags and some other things.

Using autoformatters is practically always good in my opinion.

#### Checklist:

- [x] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.
