### PR TITLE
Add show_toolbar_with_docker function for Docker IP handling

### DIFF
--- a/debug_toolbar/middleware.py
+++ b/debug_toolbar/middleware.py
@@ -31,6 +31,21 @@ def show_toolbar(request):
     if request.META.get("REMOTE_ADDR") in settings.INTERNAL_IPS:
         return True
 
+    # No test passed
+    return False
+
+
+def show_toolbar_with_docker(request):
+    """
+    Default function to determine whether to show the toolbar on a given page.
+    """
+    if not settings.DEBUG:
+        return False
+
+    # Test: settings
+    if request.META.get("REMOTE_ADDR") in settings.INTERNAL_IPS:
+        return True
+
     # Test: Docker
     try:
         # This is a hack for docker installations. It attempts to look

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -34,6 +34,10 @@ Pending
 * Fixed the pygments code highlighting when using dark mode.
 * Fix for exception-unhandled "forked" Promise chain in rebound window.fetch
 * Create a CSP nonce property on the toolbar ``Toolbar().csp_nonce``.
+* Add hook to RedirectsPanel for subclass customization
+* Added ``show_toolbar_with_docker`` function to check Docker host IP address
+  when running inside Docker containers.
+
 
 5.0.1 (2025-01-13)
 ------------------

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -155,7 +155,7 @@ option.
     If using Docker, the toolbar will attempt to look up your host name
     automatically and treat it as an allowable internal IP. If you're not
     able to get the toolbar to work with your docker installation, review
-    the code in ``debug_toolbar.middleware.show_toolbar``.
+    the code in ``debug_toolbar.middleware.show_toolbar_with_docker``.
 
 7. Disable the toolbar when running tests (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
#### Description

- Introduced a new function, show_toolbar_with_docker, to determine if the toolbar should be displayed when running inside Docker containers.
- Updated installation documentation to reference the new function for Docker configurations.
- Added a changelog entry for the new functionality.

Fixes #2113

#### Checklist:

- [ ] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.
