### PR TITLE
Keep pannel close button accessible with external styles

### DIFF
--- a/debug_toolbar/static/debug_toolbar/js/utils.js
+++ b/debug_toolbar/static/debug_toolbar/js/utils.js
@@ -90,7 +90,7 @@ function ajax(url, init) {
         })
         .catch((error) => {
             const win = document.getElementById("djDebugWindow");
-            win.innerHTML = `<div class="djDebugPanelTitle"><button type="button" class="djDebugClose">»</button><h3>${error.message}</h3></div>`;
+            win.innerHTML = `<div class="djDebugPanelTitle"><h3>${error.message}</h3><button type="button" class="djDebugClose">»</button></div>`;
             $$.show(win);
             throw error;
         });

--- a/debug_toolbar/templates/debug_toolbar/includes/panel_content.html
+++ b/debug_toolbar/templates/debug_toolbar/includes/panel_content.html
@@ -3,8 +3,8 @@
 {% if panel.has_content and panel.enabled %}
   <div id="{{ panel.panel_id }}" class="djdt-panelContent djdt-hidden">
     <div class="djDebugPanelTitle">
-      <button type="button" class="djDebugClose">×</button>
       <h3>{{ panel.title }}</h3>
+      <button type="button" class="djDebugClose">×</button>
     </div>
     <div class="djDebugPanelContent">
       {% if toolbar.should_render_panels %}

--- a/debug_toolbar/templates/debug_toolbar/panels/sql_explain.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/sql_explain.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 <div class="djDebugPanelTitle">
-  <button type="button" class="djDebugClose">»</button>
   <h3>{% translate "SQL explained" %}</h3>
+  <button type="button" class="djDebugClose">»</button>
 </div>
 <div class="djDebugPanelContent">
   <div class="djdt-scroll">

--- a/debug_toolbar/templates/debug_toolbar/panels/sql_profile.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/sql_profile.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 <div class="djDebugPanelTitle">
-  <button type="button" class="djDebugClose">»</button>
   <h3>{% translate "SQL profiled" %}</h3>
+  <button type="button" class="djDebugClose">»</button>
 </div>
 <div class="djDebugPanelContent">
   <div class="djdt-scroll">

--- a/debug_toolbar/templates/debug_toolbar/panels/sql_select.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/sql_select.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 <div class="djDebugPanelTitle">
-  <button type="button" class="djDebugClose">»</button>
   <h3>{% translate "SQL selected" %}</h3>
+  <button type="button" class="djDebugClose">»</button>
 </div>
 <div class="djDebugPanelContent">
   <div class="djdt-scroll">

--- a/debug_toolbar/templates/debug_toolbar/panels/template_source.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/template_source.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 <div class="djDebugPanelTitle">
-  <button type="button" class="djDebugClose">»</button>
   <h3>{% translate "Template source:" %} <code>{{ template_name }}</code></h3>
+  <button type="button" class="djDebugClose">»</button>
 </div>
 <div class="djDebugPanelContent">
   <div class="djdt-scroll">

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -15,7 +15,8 @@ Pending
   template loaders.
 * Introduced `djade <https://github.com/adamchainz/djade>`__ to format Django
   templates.
-* Swapped display order of panel header and close button to prevent style conflicts
+* Swapped display order of panel header and close button to prevent style
+  conflicts
 
 5.1.0 (2025-03-20)
 ------------------

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -15,6 +15,7 @@ Pending
   template loaders.
 * Introduced `djade <https://github.com/adamchainz/djade>`__ to format Django
   templates.
+* Swapped display order of panel header and close button to prevent style conflicts
 
 5.1.0 (2025-03-20)
 ------------------

--- a/tests/panels/test_custom.py
+++ b/tests/panels/test_custom.py
@@ -33,8 +33,8 @@ class CustomPanelTestCase(IntegrationTestCase):
             """
             <div id="CustomPanel" class="djdt-panelContent djdt-hidden">
             <div class="djDebugPanelTitle">
-            <button type="button" class="djDebugClose">×</button>
             <h3>Title with special chars &amp;&quot;&#39;&lt;&gt;</h3>
+            <button type="button" class="djDebugClose">×</button>
             </div>
             <div class="djDebugPanelContent">
             <div class="djdt-loader"></div>

--- a/tests/panels/test_settings.py
+++ b/tests/panels/test_settings.py
@@ -24,8 +24,8 @@ class SettingsIntegrationTestCase(IntegrationTestCase):
             """
             <div id="SettingsPanel" class="djdt-panelContent djdt-hidden">
             <div class="djDebugPanelTitle">
-            <button type="button" class="djDebugClose">×</button>
             <h3>Settings from None</h3>
+            <button type="button" class="djDebugClose">×</button>
             </div>
             <div class="djDebugPanelContent">
             <div class="djdt-loader"></div>

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -812,7 +812,7 @@ class DebugToolbarLiveTestCase(StaticLiveServerTestCase):
         debug_window = self.selenium.find_element(By.ID, "djDebugWindow")
         self.selenium.find_element(By.CLASS_NAME, "BuggyPanel").click()
         self.wait.until(EC.visibility_of(debug_window))
-        self.assertEqual(debug_window.text, "»\n500: Internal Server Error")
+        self.assertEqual(debug_window.text, "500: Internal Server Error\n»")
 
     def test_toolbar_language_will_render_to_default_language_when_not_set(self):
         self.get("/regular/basic/")


### PR DESCRIPTION
#### Description

External styles such as [missing.css](https://missing.style/) can interfere with the display of the panel header elements, and since these are currently rendered after the button they can appear ontop and block click events from passing through. Fix was fairly straightforward, have just swapped the order of display everwhere I could find these pairs of elements.

Fixes #2083

While the selenium tests are all working, I haven't quite figured out how I could incorporate a regression test for this. I've narrowed the offending css down to this rule:

```css
h1,h2,h3,h4,h5,h6 {
  position:relative;
} 
```

And I've tested manually that this will break the close button before this PR and not after, but I can't quite see how to approach setting up a test case for this. The test cases I've edited do at least assert that the content of the button is rendered after the headers, so it is indirectly tested for, perhaps that is suffient?

#### Checklist:

- [x] I have added the relevant tests for this change (edited existing tests)
- [x] I have added an item to the Pending section of ``docs/changes.rst``.
