### PR TITLE
Add CSS resets for height and min-height

### DIFF
--- a/debug_toolbar/static/debug_toolbar/css/toolbar.css
+++ b/debug_toolbar/static/debug_toolbar/css/toolbar.css
@@ -127,8 +127,10 @@
 #djDebug button {
     margin: 0;
     padding: 0;
-    min-width: 0;
+    min-width: auto;
     width: auto;
+    min-height: auto;
+    height: auto;
     border: 0;
     outline: 0;
     font-size: 12px;

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -17,6 +17,8 @@ Pending
   templates.
 * Swapped display order of panel header and close button to prevent style
   conflicts
+* Added CSS for resetting the height of elements too to avoid problems with
+  global CSS of a website where the toolbar is used.
 
 5.1.0 (2025-03-20)
 ------------------


### PR DESCRIPTION
Refs https://github.com/django/djangoproject.com/pull/2041.

#### Description

Our CSS doesn't reset the height of elements to the default value of auto.
This causes problems when a site's CSS uses unscoped element styles.

(According to MDN the default value of min-width is auto as well.)

#### Checklist:

- [ ] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.
