### PR TITLE
Remove pin for django-csp.

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,6 +11,7 @@ html5lib
 selenium
 tox
 black
+django-template-partials
 django-csp # Used in tests/test_csp_rendering
 
 # Integration support

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,7 +11,7 @@ html5lib
 selenium
 tox
 black
-django-csp<4 # Used in tests/test_csp_rendering
+django-csp # Used in tests/test_csp_rendering
 
 # Integration support
 


### PR DESCRIPTION
The toolbar now supports django-csp v4

#### Description

Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context. Your commit message should include
this information as well.

Fixes #2129

#### Checklist:

- [ ] I have added the relevant tests for this change.
- [ ] I have added an item to the Pending section of ``docs/changes.rst``.
