### PR TITLE
Disabled document.cookie linter

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -38,6 +38,9 @@
                 "useExportType": "error",
                 "noUselessElse": "error",
                 "useShorthandFunctionType": "error"
+            },
+            "suspicious": {
+                "noDocumentCookie": "off"
             }
         }
     },


### PR DESCRIPTION
The replacement, CookieStore isn't accessible on all browsers at this time, nor should we assume we always have access to secure environments.

#### Checklist:

- [ ] I have added the relevant tests for this change.
- [ ] I have added an item to the Pending section of ``docs/changes.rst``.
