### PR TITLE
Deduplicate staticfiles

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -30,6 +30,7 @@ Pending
 * Extend example app to contain an async version.
 * Added ``debug_toolbar.store.DatabaseStore`` for persistent debug data
   storage.
+* Deduplicated static files in the staticfiles panel.
 
 5.2.0 (2025-04-29)
 ------------------

--- a/tests/templates/staticfiles/path.html
+++ b/tests/templates/staticfiles/path.html
@@ -1,1 +1,3 @@
-{% load static %}{% static path %}
+{% load static %}
+{# A single file used twice #}
+{% static path %}{% static path %}


### PR DESCRIPTION
#### Description

Currently, the staticfiles panel contains one entry per `static()` call. That's not the same thing as used staticfiles, since assets can be deduplicated in multiple ways, e.g. through `forms.Media` or because the browser actually understands that it should load `<script type="module">` once only.

I think it makes more sense to show a deduplicated and sorted list of static files used.

Refs https://github.com/matthiask/django-prose-editor/issues/48

#### Checklist:

- [ ] I have added the relevant tests for this change.
- [ ] I have added an item to the Pending section of ``docs/changes.rst``.
