### PR TITLE
Fixes #2158 -- Made static file objects orderable

### DIFF
--- a/debug_toolbar/panels/staticfiles.py
+++ b/debug_toolbar/panels/staticfiles.py
@@ -11,7 +11,7 @@ from django.utils.translation import gettext_lazy as _, ngettext
 from debug_toolbar import panels
 
 
-@dataclass(eq=True, frozen=True)
+@dataclass(eq=True, frozen=True, order=True)
 class StaticFile:
     """
     Representing the different properties of a static file.

--- a/tests/panels/test_staticfiles.py
+++ b/tests/panels/test_staticfiles.py
@@ -65,19 +65,25 @@ class StaticFilesPanelTestCase(BaseTestCase):
 
     def test_path(self):
         def get_response(request):
-            # template contains one static file
             return render(
                 request,
                 "staticfiles/path.html",
-                {"path": Path("additional_static/base.css")},
+                {
+                    "paths": [
+                        Path("additional_static/base.css"),
+                        Path("additional_static/base.css"),
+                        Path("additional_static/base2.css"),
+                    ]
+                },
             )
 
         self._get_response = get_response
         request = RequestFactory().get("/")
         response = self.panel.process_request(request)
         self.panel.generate_stats(self.request, response)
-        self.assertEqual(self.panel.get_stats()["num_used"], 1)
-        self.assertIn('"/static/additional_static/base.css"', self.panel.content)
+        self.assertEqual(self.panel.get_stats()["num_used"], 2)
+        self.assertIn('"/static/additional_static/base.css"', self.panel.content, 1)
+        self.assertIn('"/static/additional_static/base2.css"', self.panel.content, 1)
 
     def test_storage_state_preservation(self):
         """Ensure the URLMixin doesn't affect storage state"""

--- a/tests/templates/staticfiles/path.html
+++ b/tests/templates/staticfiles/path.html
@@ -1,3 +1,1 @@
-{% load static %}
-{# A single file used twice #}
-{% static path %}{% static path %}
+{% load static %}{% for path in paths %}{% static path %}{% endfor %}


### PR DESCRIPTION
#### Description

#2155 introduced deduplication and sorting of static files, however the `StaticFile` object wasn't orderable at all.

Fixes #2158 

#### Checklist:

- [x] I have added the relevant tests for this change.
- [ ] I have added an item to the Pending section of ``docs/changes.rst``.
