### PR TITLE
Fixes #2160 -- Corrected links to static files

### DIFF
--- a/debug_toolbar/panels/staticfiles.py
+++ b/debug_toolbar/panels/staticfiles.py
@@ -1,7 +1,6 @@
 import contextlib
 import uuid
 from contextvars import ContextVar
-from dataclasses import dataclass
 from os.path import join, normpath
 
 from django.contrib.staticfiles import finders, storage
@@ -9,26 +8,6 @@ from django.dispatch import Signal
 from django.utils.translation import gettext_lazy as _, ngettext
 
 from debug_toolbar import panels
-
-
-@dataclass(eq=True, frozen=True, order=True)
-class StaticFile:
-    """
-    Representing the different properties of a static file.
-    """
-
-    path: str
-    url: str
-
-    def __str__(self):
-        return self.path
-
-    def real_path(self):
-        return finders.find(self.path)
-
-    def url(self):
-        return self._url
-
 
 # This will record and map the StaticFile instances with its associated
 # request across threads and async concurrent requests state.
@@ -47,7 +26,7 @@ class URLMixin:
             request_id = request_id_context_var.get()
             record_static_file_signal.send(
                 sender=self,
-                staticfile=StaticFile(path=str(path), url=url),
+                staticfile=(str(path), url, finders.find(str(path))),
                 request_id=request_id,
             )
         return url

--- a/debug_toolbar/templates/debug_toolbar/panels/staticfiles.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/staticfiles.html
@@ -25,9 +25,9 @@
 <h4>{% blocktranslate count staticfiles_count=staticfiles|length %}Static file{% plural %}Static files{% endblocktranslate %}</h4>
 {% if staticfiles %}
   <dl>
-    {% for staticfile in staticfiles %}
-      <dt><strong><a class="toggleTemplate" href="{{ staticfile.url }}">{{ staticfile }}</a></strong></dt>
-      <dd><samp>{{ staticfile.real_path }}</samp></dd>
+    {% for path, url, real_path in staticfiles %}
+      <dt><strong><a class="toggleTemplate" href="{{ url }}" target="_blank" rel="noopener">{{ path }}</a></strong></dt>
+      <dd><samp>{{ real_path }}</samp></dd>
     {% endfor %}
   </dl>
 {% else %}

--- a/tests/panels/test_staticfiles.py
+++ b/tests/panels/test_staticfiles.py
@@ -71,8 +71,8 @@ class StaticFilesPanelTestCase(BaseTestCase):
                 {
                     "paths": [
                         Path("additional_static/base.css"),
-                        Path("additional_static/base.css"),
-                        Path("additional_static/base2.css"),
+                        "additional_static/base.css",
+                        "additional_static/base2.css",
                     ]
                 },
             )
@@ -82,8 +82,12 @@ class StaticFilesPanelTestCase(BaseTestCase):
         response = self.panel.process_request(request)
         self.panel.generate_stats(self.request, response)
         self.assertEqual(self.panel.get_stats()["num_used"], 2)
-        self.assertIn('"/static/additional_static/base.css"', self.panel.content, 1)
-        self.assertIn('"/static/additional_static/base2.css"', self.panel.content, 1)
+        self.assertIn(
+            'href="/static/additional_static/base.css"', self.panel.content, 1
+        )
+        self.assertIn(
+            'href="/static/additional_static/base2.css"', self.panel.content, 1
+        )
 
     def test_storage_state_preservation(self):
         """Ensure the URLMixin doesn't affect storage state"""


### PR DESCRIPTION


#### Description

The JSON serialization used by the new serializable mechanism compressed the `StaticFile` dataclass down to a single string without an `.url` attribute. Change the code to use a tuple instead to avoid this problem.

Fixes #2160 

#### Checklist:

- [ ] I have added the relevant tests for this change.
- [ ] I have added an item to the Pending section of ``docs/changes.rst``.
