### PR TITLE
Fixes 2151 -- Forwarded args and kwargs in URLMixin.url

### DIFF
--- a/debug_toolbar/panels/staticfiles.py
+++ b/debug_toolbar/panels/staticfiles.py
@@ -16,8 +16,8 @@ record_static_file_signal = Signal()
 
 
 class URLMixin:
-    def url(self, path):
-        url = super().url(path)
+    def url(self, path, *args, **kwargs):
+        url = super().url(path, *args, **kwargs)
         with contextlib.suppress(LookupError):
             # For LookupError:
             # The ContextVar wasn't set yet. Since the toolbar wasn't properly


### PR DESCRIPTION
#### Description

Some static file storages have additional arguments to `.url()`, for example to return a non-hashed URL in debug mode, see https://github.com/django/django/blob/a8536e33da6365fb7bba901a06a67d163d0d4c8a/django/contrib/staticfiles/storage.py#L201

I think this change doesn't strictly require tests, but I'm happy to postpone this if we don't want to do this without tests.

Fixes #2151 

#### Checklist:

- [ ] I have added the relevant tests for this change.
- [ ] I have added an item to the Pending section of ``docs/changes.rst``.
