### PR TITLE
Fixes #2159 -- Do not HTML-escape traces in the cache and profiling panel

### DIFF
--- a/debug_toolbar/templates/debug_toolbar/panels/cache.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/cache.html
@@ -61,7 +61,7 @@
         </tr>
         <tr class="djUnselected djToggleDetails_{{ forloop.counter }}" id="cacheDetails_{{ forloop.counter }}">
           <td colspan="1"></td>
-          <td colspan="5"><pre class="djdt-stack">{{ call.trace }}</pre></td>
+          <td colspan="5"><pre class="djdt-stack">{{ call.trace|safe }}</pre></td>
         </tr>
       {% endfor %}
     </tbody>

--- a/debug_toolbar/templates/debug_toolbar/panels/profiling.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/profiling.html
@@ -20,7 +20,7 @@
             {% else %}
               <span class="djNoToggleSwitch"></span>
             {% endif %}
-            <span class="djdt-stack">{{ call.func_std_string }}</span>
+            <span class="djdt-stack">{{ call.func_std_string|safe }}</span>
           </div>
         </td>
         <td>{{ call.cumtime|floatformat:3 }}</td>

--- a/tests/base.py
+++ b/tests/base.py
@@ -112,6 +112,10 @@ class BaseMixin:
                 msg_parts.append(f"    {lines[position[0] - 1]}")
             raise self.failureException("\n".join(msg_parts))
 
+    def reload_stats(self):
+        data = self.toolbar.store.panel(self.toolbar.request_id, self.panel_id)
+        self.panel.load_stats_from_store(data)
+
 
 class BaseTestCase(BaseMixin, TestCase):
     pass

--- a/tests/panels/test_cache.py
+++ b/tests/panels/test_cache.py
@@ -124,10 +124,13 @@ class CachePanelTestCase(BaseTestCase):
         # ensure the panel does not have content yet.
         self.assertNotIn("café", self.panel.content)
         self.panel.generate_stats(self.request, response)
+        self.reload_stats()
         # ensure the panel renders correctly.
         content = self.panel.content
         self.assertIn("café", content)
         self.assertValidHTML(content)
+        # ensure traces aren't escaped
+        self.assertIn('<span class="djdt-path">', content)
 
     def test_generate_server_timing(self):
         self.assertEqual(len(self.panel.calls), 0)

--- a/tests/panels/test_profiling.py
+++ b/tests/panels/test_profiling.py
@@ -35,11 +35,14 @@ class ProfilingPanelTestCase(BaseTestCase):
         # ensure the panel does not have content yet.
         self.assertNotIn("regular_view", self.panel.content)
         self.panel.generate_stats(self.request, response)
+        self.reload_stats()
         # ensure the panel renders correctly.
         content = self.panel.content
         self.assertIn("regular_view", content)
         self.assertIn("render", content)
         self.assertValidHTML(content)
+        # ensure traces aren't escaped
+        self.assertIn('<span class="djdt-path">', content)
 
     @override_settings(DEBUG_TOOLBAR_CONFIG={"PROFILER_THRESHOLD_RATIO": 1})
     def test_cum_time_threshold(self):

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -2,6 +2,7 @@ import uuid
 
 from django.test import TestCase
 from django.test.utils import override_settings
+from django.utils.safestring import SafeData, mark_safe
 
 from debug_toolbar import store
 
@@ -96,6 +97,18 @@ class MemoryStoreTestCase(TestCase):
         self.assertEqual(self.store.panel("missing", "missing"), {})
         self.store.save_panel("bar", "bar.panel", {"a": 1})
         self.assertEqual(self.store.panel("bar", "bar.panel"), {"a": 1})
+
+    def test_serialize_safestring(self):
+        before = {"string": mark_safe("safe")}
+
+        self.store.save_panel("bar", "bar.panel", before)
+        after = self.store.panel("bar", "bar.panel")
+
+        self.assertFalse(type(before["string"]) is str)
+        self.assertTrue(isinstance(before["string"], SafeData))
+
+        self.assertTrue(type(after["string"]) is str)
+        self.assertFalse(isinstance(after["string"], SafeData))
 
 
 class StubStore(store.BaseStore):


### PR DESCRIPTION
#### Description

The panel data has to be explicitly reloaded from the store to hit this case. The new ``reload_stats`` utility helps with this.

Fixes #2159

#### Checklist:

- [x] I have added the relevant tests for this change.
- [ ] I have added an item to the Pending section of ``docs/changes.rst``.
