### PR TITLE
Added a note about the default password in make example

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,11 @@
 Change log
 ==========
 
+Pending
+-------
+
+* Added a note about the default password in ``make example``.
+
 6.0.0 (2025-07-22)
 ------------------
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -40,6 +40,9 @@ For convenience, there's an alias for the second command::
 
     $ make example
 
+The default password is ``p``, it can be overridden by setting the environment
+variable ``DJANGO_SUPERUSER_PASSWORD``.
+
 Look at ``example/settings.py`` for running the example with another database
 than SQLite.
 


### PR DESCRIPTION
#### Description

When I started to contribute at first the default password was not clear and I had to look at the makefile

#### Checklist:

- [ ] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.
