### PR TITLE
Removed logging about the toolbar failing to serialize a value into JSON

### DIFF
--- a/debug_toolbar/store.py
+++ b/debug_toolbar/store.py
@@ -1,6 +1,5 @@
 import contextlib
 import json
-import logging
 from collections import defaultdict, deque
 from collections.abc import Iterable
 from typing import Any
@@ -13,15 +12,12 @@ from django.utils.module_loading import import_string
 from debug_toolbar import settings as dt_settings
 from debug_toolbar.models import HistoryEntry
 
-logger = logging.getLogger(__name__)
-
 
 class DebugToolbarJSONEncoder(DjangoJSONEncoder):
     def default(self, o):
         try:
             return super().default(o)
         except (TypeError, ValueError):
-            logger.debug("The debug toolbar can't serialize %s into JSON" % o)
             return force_str(o)
 
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,11 @@
 Change log
 ==========
 
+Pending
+-------
+
+* Removed logging about the toolbar failing to serialize a value into JSON.
+
 6.0.0 (2025-07-22)
 ------------------
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -14,6 +14,12 @@ class SerializationTestCase(TestCase):
             '{"hello": {"foo": "bar"}}',
         )
 
+    def test_serialize_logs_on_failure(self):
+        self.assertEqual(
+            store.serialize({"hello": {"foo": b"bar"}}),
+            '{"hello": {"foo": "bar"}}',
+        )
+
     def test_deserialize(self):
         self.assertEqual(
             store.deserialize('{"hello": {"foo": "bar"}}'),


### PR DESCRIPTION
#### Description

I considered using a named logger, but then realized we may run into issues where we're logging sensitive values unexpectedly in a project. It's probably better to remove this and just ask whoever when they are debugging to add a print statement (or similar).

Fixes #2171

#### Checklist:

- [x] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.
