### PR TITLE
Fix PostgreSQL compatibility issues in CI and SQL profiling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,222 +1,218 @@
 name: Test
 
 on:
-  push:
-  pull_request:
-  schedule:
-    # Run weekly on Saturday
-    - cron: '37 3 * * SAT'
+    push:
+    pull_request:
+    schedule:
+        # Run weekly on Saturday
+        - cron: "37 3 * * SAT"
 
 jobs:
-  mysql:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      max-parallel: 5
-      matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+    mysql:
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            max-parallel: 5
+            matrix:
+                python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
-    services:
-      mariadb:
-        image: mariadb
-        env:
-          MARIADB_ROOT_PASSWORD: debug_toolbar
-        options: >-
-          --health-cmd "mariadb-admin ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-        - 3306:3306
+        services:
+            mariadb:
+                image: mariadb
+                env:
+                    MARIADB_ROOT_PASSWORD: debug_toolbar
+                options: >-
+                    --health-cmd "mariadb-admin ping"
+                    --health-interval 10s
+                    --health-timeout 5s
+                    --health-retries 5
+                ports:
+                    - 3306:3306
 
-    steps:
-    - uses: actions/checkout@v4
+        steps:
+            - uses: actions/checkout@v4
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-        allow-prereleases: true
+            - name: Set up Python ${{ matrix.python-version }}
+              uses: actions/setup-python@v5
+              with:
+                  python-version: ${{ matrix.python-version }}
+                  allow-prereleases: true
 
-    - name: Get pip cache dir
-      id: pip-cache
-      run: |
-        echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+            - name: Get pip cache dir
+              id: pip-cache
+              run: |
+                  echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
-    - name: Cache
-      uses: actions/cache@v4
-      with:
-        path: ${{ steps.pip-cache.outputs.dir }}
-        key:
-          ${{ matrix.python-version }}-v1-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/tox.ini') }}
-        restore-keys: |
-          ${{ matrix.python-version }}-v1-
+            - name: Cache
+              uses: actions/cache@v4
+              with:
+                  path: ${{ steps.pip-cache.outputs.dir }}
+                  key: ${{ matrix.python-version }}-v1-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/tox.ini') }}
+                  restore-keys: |
+                      ${{ matrix.python-version }}-v1-
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install --upgrade tox tox-gh-actions
+            - name: Install dependencies
+              run: |
+                  python -m pip install --upgrade pip
+                  python -m pip install --upgrade tox tox-gh-actions
 
-    - name: Test with tox
-      run: tox
-      env:
-        DB_BACKEND: mysql
-        DB_USER: root
-        DB_PASSWORD: debug_toolbar
-        DB_HOST: 127.0.0.1
-        DB_PORT: 3306
+            - name: Test with tox
+              run: tox
+              env:
+                  DB_BACKEND: mysql
+                  DB_USER: root
+                  DB_PASSWORD: debug_toolbar
+                  DB_HOST: 127.0.0.1
+                  DB_PORT: 3306
 
+    postgres:
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            max-parallel: 5
+            matrix:
+                # Skip 3.13 here, it needs the psycopg3 / postgis3 database
+                python-version: ["3.9", "3.10", "3.11", "3.12"]
+                database: [postgresql, postgis]
+                # Add psycopg3 to our matrix for modern python versions
+                include:
+                    - python-version: "3.10"
+                      database: psycopg3
+                    - python-version: "3.11"
+                      database: psycopg3
+                    - python-version: "3.12"
+                      database: psycopg3
+                    - python-version: "3.13"
+                      database: psycopg3
+                    - python-version: "3.13"
+                      database: postgis3
 
-  postgres:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      max-parallel: 5
-      matrix:
-        # Skip 3.13 here, it needs the psycopg3 / postgis3 database
-        python-version: ['3.9', '3.10', '3.11', '3.12']
-        database: [postgresql, postgis]
-        # Add psycopg3 to our matrix for modern python versions
-        include:
-            - python-version: '3.10'
-              database: psycopg3
-            - python-version: '3.11'
-              database: psycopg3
-            - python-version: '3.12'
-              database: psycopg3
-            - python-version: '3.13'
-              database: psycopg3
-            - python-version: '3.13'
-              database: postgis3
+        services:
+            postgres:
+                image: postgis/postgis:14-3.1
+                env:
+                    POSTGRES_DB: debug_toolbar
+                    POSTGRES_USER: debug_toolbar
+                    POSTGRES_PASSWORD: debug_toolbar
+                ports:
+                    - 5432:5432
+                options: >-
+                    --health-cmd pg_isready
+                    --health-interval 10s
+                    --health-timeout 5s
+                    --health-retries 5
 
-    services:
-      postgres:
-        image: postgis/postgis:14-3.1
-        env:
-          POSTGRES_DB: debug_toolbar
-          POSTGRES_USER: debug_toolbar
-          POSTGRES_PASSWORD: debug_toolbar
-        ports:
-        - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+        steps:
+            - uses: actions/checkout@v4
 
-    steps:
-    - uses: actions/checkout@v4
+            - name: Set up Python ${{ matrix.python-version }}
+              uses: actions/setup-python@v5
+              with:
+                  python-version: ${{ matrix.python-version }}
+                  allow-prereleases: true
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-        allow-prereleases: true
+            - name: Get pip cache dir
+              id: pip-cache
+              run: |
+                  echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
-    - name: Get pip cache dir
-      id: pip-cache
-      run: |
-        echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+            - name: Cache
+              uses: actions/cache@v4
+              with:
+                  path: ${{ steps.pip-cache.outputs.dir }}
+                  key: ${{ matrix.python-version }}-v1-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/tox.ini') }}
+                  restore-keys: |
+                      ${{ matrix.python-version }}-v1-
 
-    - name: Cache
-      uses: actions/cache@v4
-      with:
-        path: ${{ steps.pip-cache.outputs.dir }}
-        key:
-          ${{ matrix.python-version }}-v1-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/tox.ini') }}
-        restore-keys: |
-          ${{ matrix.python-version }}-v1-
+            - name: Install gdal-bin (for postgis)
+              run: |
+                  sudo apt-get -qq update
+                  sudo apt-get -y install gdal-bin
 
-    - name: Install gdal-bin (for postgis)
-      run: |
-        sudo apt-get -qq update
-        sudo apt-get -y install gdal-bin
+            - name: Install dependencies
+              run: |
+                  python -m pip install --upgrade pip
+                  python -m pip install --upgrade tox tox-gh-actions
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install --upgrade tox tox-gh-actions
+            - name: Test with tox
+              run: tox
+              env:
+                  DB_BACKEND: ${{ matrix.database }}
+                  DB_NAME: debug_toolbar
+                  DB_USER: debug_toolbar
+                  DB_PASSWORD: debug_toolbar
+                  DB_HOST: localhost
+                  DB_PORT: 5432
 
-    - name: Test with tox
-      run: tox
-      env:
-        DB_BACKEND: ${{ matrix.database }}
-        DB_HOST: localhost
-        DB_PORT: 5432
+    sqlite:
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            max-parallel: 5
+            matrix:
+                python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
-  sqlite:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      max-parallel: 5
-      matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        steps:
+            - uses: actions/checkout@v4
 
-    steps:
-    - uses: actions/checkout@v4
+            - name: Set up Python ${{ matrix.python-version }}
+              uses: actions/setup-python@v5
+              with:
+                  python-version: ${{ matrix.python-version }}
+                  allow-prereleases: true
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-        allow-prereleases: true
+            - name: Get pip cache dir
+              id: pip-cache
+              run: |
+                  echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
-    - name: Get pip cache dir
-      id: pip-cache
-      run: |
-        echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+            - name: Cache
+              uses: actions/cache@v4
+              with:
+                  path: ${{ steps.pip-cache.outputs.dir }}
+                  key: ${{ matrix.python-version }}-v1-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/tox.ini') }}
+                  restore-keys: |
+                      ${{ matrix.python-version }}-v1-
 
-    - name: Cache
-      uses: actions/cache@v4
-      with:
-        path: ${{ steps.pip-cache.outputs.dir }}
-        key:
-          ${{ matrix.python-version }}-v1-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/tox.ini') }}
-        restore-keys: |
-          ${{ matrix.python-version }}-v1-
+            - name: Install dependencies
+              run: |
+                  python -m pip install --upgrade pip
+                  python -m pip install --upgrade tox tox-gh-actions
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install --upgrade tox tox-gh-actions
+            - name: Test with tox
+              run: tox
+              env:
+                  DB_BACKEND: sqlite3
+                  DB_NAME: ":memory:"
 
-    - name: Test with tox
-      run: tox
-      env:
-        DB_BACKEND: sqlite3
-        DB_NAME: ":memory:"
+    lint:
+        runs-on: ubuntu-latest
 
-  lint:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
+        steps:
+            - uses: actions/checkout@v4
 
-    steps:
-    - uses: actions/checkout@v4
+            - name: Set up Python
+              uses: actions/setup-python@v5
+              with:
+                  python-version: 3.9
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: 3.9
+            - name: Get pip cache dir
+              id: pip-cache
+              run: |
+                  echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
-    - name: Get pip cache dir
-      id: pip-cache
-      run: |
-        echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+            - name: Cache
+              uses: actions/cache@v4
+              with:
+                  path: ${{ steps.pip-cache.outputs.dir }}
+                  key: 3.9-v1-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/tox.ini') }}
+                  restore-keys: |
+                      3.9-v1-
 
-    - name: Cache
-      uses: actions/cache@v4
-      with:
-        path: ${{ steps.pip-cache.outputs.dir }}
-        key:
-          ${{ matrix.python-version }}-v1-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/tox.ini') }}
-        restore-keys: |
-          ${{ matrix.python-version }}-v1-
+            - name: Install dependencies
+              run: |
+                  python -m pip install --upgrade pip
+                  python -m pip install --upgrade tox
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install --upgrade tox
-
-    - name: Test with tox
-      run: tox -e docs,packaging
+            - name: Test with tox
+              run: tox -e docs,packaging

--- a/debug_toolbar/panels/sql/forms.py
+++ b/debug_toolbar/panels/sql/forms.py
@@ -102,6 +102,15 @@ class SQLSelectForm(forms.Form):
         query = self.cleaned_data["query"]
         sql = query["raw_sql"]
         params = json.loads(query["params"])
+        vendor = query["vendor"]
+
+        # Profiling is only supported on MySQL
+        if vendor != "mysql":
+            raise ValueError(
+                f"Profiling is not supported for {vendor}. "
+                "Profiling is only available for MySQL databases."
+            )
+
         with self.cursor as cursor:
             cursor.execute("SET PROFILING=1")  # Enable profiling
             cursor.execute(sql, params)  # Execute SELECT

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -6,6 +6,9 @@ Pending
 
 * Added a note about the default password in ``make example``.
 * Removed logging about the toolbar failing to serialize a value into JSON.
+* Fixed PostgreSQL compatibility issues: SQL profiling now properly detects
+  MySQL requirement and provides clear error messages for other databases.
+  Fixed CI configuration to use correct PostgreSQL credentials.
 
 6.0.0 (2025-07-22)
 ------------------

--- a/tests/test_postgresql_compatibility.py
+++ b/tests/test_postgresql_compatibility.py
@@ -1,0 +1,74 @@
+"""
+Tests for PostgreSQL compatibility fixes
+"""
+
+from django.db import connection
+from django.test import TestCase
+
+from debug_toolbar.panels.sql.forms import SQLSelectForm
+
+
+class PostgreSQLCompatibilityTestCase(TestCase):
+    """
+    Test that PostgreSQL-specific compatibility issues are handled correctly.
+    """
+
+    def test_profiling_only_supported_on_mysql(self):
+        """
+        Test that profiling raises appropriate error for non-MySQL databases.
+        """
+        # Skip this test if we're actually using MySQL
+        if connection.vendor == "mysql":
+            self.skipTest("This test is for non-MySQL databases")
+
+        # Create a form and mock the cleaned_data to test profile method
+        form = SQLSelectForm()
+        form.cleaned_data = {
+            "query": {
+                "vendor": connection.vendor,
+                "alias": "default",
+                "raw_sql": "SELECT 1",
+                "params": "[]",
+            }
+        }
+
+        # Test that profiling raises ValueError for non-MySQL databases
+        with self.assertRaises(ValueError) as cm:
+            form.profile()
+
+        self.assertIn("Profiling is not supported", str(cm.exception))
+        self.assertIn(connection.vendor, str(cm.exception))
+
+    def test_profiling_mysql_check(self):
+        """
+        Test that profiling only allows MySQL vendor.
+        """
+        form = SQLSelectForm()
+
+        # Test with PostgreSQL
+        form.cleaned_data = {
+            "query": {
+                "vendor": "postgresql",
+                "alias": "default",
+                "raw_sql": "SELECT 1",
+                "params": "[]",
+            }
+        }
+
+        with self.assertRaises(ValueError) as cm:
+            form.profile()
+        self.assertIn("Profiling is not supported for postgresql", str(cm.exception))
+
+        # Test with SQLite
+        form.cleaned_data = {
+            "query": {
+                "vendor": "sqlite",
+                "alias": "default",
+                "raw_sql": "SELECT 1",
+                "params": "[]",
+            }
+        }
+
+        with self.assertRaises(ValueError) as cm:
+            form.profile()
+        self.assertIn("Profiling is not supported for sqlite", str(cm.exception))


### PR DESCRIPTION
#### Description

This PR fixes PostgreSQL compatibility issues that were causing CI pipeline failures. The main issue was that the SQL panel's profiling feature was attempting to use MySQL-specific commands on PostgreSQL databases, resulting in errors like "unrecognized configuration parameter profiling".

Additionally, the CI configuration had missing environment variables for PostgreSQL test jobs and a malformed lint job configuration.

**Key Changes:**
- Added vendor detection to SQL panel profiling to prevent MySQL-specific commands on other databases
- Fixed CI PostgreSQL job environment variables (DB_NAME, DB_USER, DB_PASSWORD)
- Fixed malformed lint job strategy configuration
- Added comprehensive tests for PostgreSQL compatibility

**Root Cause:** The `SQLSelectForm.profile()` method was executing MySQL-specific `SET PROFILING` commands and querying `information_schema.profiling` without checking the database vendor, causing PostgreSQL CI jobs to fail.

**Solution:** Added vendor detection that raises a clear `ValueError` for non-MySQL databases, preventing the MySQL-specific code from executing on PostgreSQL/SQLite.

Fixes #2185

#### Checklist:

- [x] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.