### PR TITLE
Add SQLPanel support for DDT model query tracking

### DIFF
--- a/debug_toolbar/panels/sql/tracking.py
+++ b/debug_toolbar/panels/sql/tracking.py
@@ -8,6 +8,7 @@ import django.test.testcases
 from django.utils.encoding import force_str
 
 from debug_toolbar.utils import get_stack_trace, get_template_info
+from django.apps import apps
 
 try:
     import psycopg
@@ -26,6 +27,17 @@ except ImportError:
 # by the TemplatePanel to prevent the toolbar from issuing
 # additional queries.
 allow_sql = contextvars.ContextVar("debug-toolbar-allow-sql", default=True)
+
+# Prevents tracking of DDT models
+allow_ddt_models_tracking = contextvars.ContextVar(
+    "debug-toolbar-allow-ddt-models", default=False
+)
+
+DDT_MODELS = {
+    m._meta.db_table
+    for m in apps.get_app_config("debug_toolbar").get_models()
+    if m._meta.app_label == "debug_toolbar"
+}
 
 
 class SQLQueryTriggered(Exception):
@@ -223,6 +235,12 @@ class NormalCursorMixin(DjDTCursorWrapperMixin):
                         "iso_level": iso_level,
                     }
                 )
+
+            # Skip recording if query includes DDT models.
+            if not allow_ddt_models_tracking.get() and any(
+                table in sql for table in DDT_MODELS
+            ):
+                return
 
             # We keep `sql` to maintain backwards compatibility
             self.logger.record(**kwargs)

--- a/tests/panels/test_sql.py
+++ b/tests/panels/test_sql.py
@@ -16,6 +16,7 @@ from django.test.utils import override_settings
 
 import debug_toolbar.panels.sql.tracking as sql_tracking
 from debug_toolbar.panels.sql import SQLPanel
+from debug_toolbar.models import HistoryEntry
 
 try:
     import psycopg
@@ -31,6 +32,20 @@ def sql_call(*, use_iterator=False):
     if use_iterator:
         qs = qs.iterator()
     return list(qs)
+
+
+def sql_call_ddt(*, use_iterator=False):
+    qs = HistoryEntry.objects.all()
+    if use_iterator:
+        qs = qs.iterator()
+    return list(qs)
+
+
+async def async_sql_call_ddt(*, use_iterator=False):
+    qs = HistoryEntry.objects.all()
+    if use_iterator:
+        qs = qs.iterator()
+    return await sync_to_async(list)(qs)
 
 
 async def async_sql_call(*, use_iterator=False):
@@ -103,6 +118,64 @@ class SQLPanelTestCase(BaseTestCase):
 
         # ensure the stacktrace is populated
         self.assertTrue(len(query["stacktrace"]) > 0)
+
+    def test_ddt_models_tracking(self):
+        self.assertEqual(len(self.panel._queries), 0)
+
+        # enable ddt tracking
+        sql_tracking.allow_ddt_models_tracking.set(True)
+
+        sql_call_ddt()
+
+        # ensure query was logged
+        self.assertEqual(len(self.panel._queries), 1)
+        query = self.panel._queries[0]
+        self.assertEqual(query["alias"], "default")
+        self.assertTrue("sql" in query)
+        self.assertTrue("duration" in query)
+        self.assertTrue("stacktrace" in query)
+
+        # ensure the stacktrace is populated
+        self.assertTrue(len(self.panel._queries), 0)
+
+    async def test_ddt_models_tracking_async(self):
+        self.assertEqual(len(self.panel._queries), 0)
+
+        # enable ddt tracking
+        sql_tracking.allow_ddt_models_tracking.set(True)
+
+        await async_sql_call_ddt()
+
+        # ensure query was logged
+        self.assertEqual(len(self.panel._queries), 1)
+        query = self.panel._queries[0]
+        self.assertEqual(query["alias"], "default")
+        self.assertTrue("sql" in query)
+        self.assertTrue("duration" in query)
+        self.assertTrue("stacktrace" in query)
+
+        # ensure the stacktrace is populated
+        self.assertTrue(len(self.panel._queries), 0)
+
+    def test_ddt_models_untracking(self):
+        self.assertEqual(len(self.panel._queries), 0)
+
+        # disable ddt tracking
+        sql_tracking.allow_ddt_models_tracking.set(False)
+
+        sql_call_ddt()
+
+        self.assertEqual(len(self.panel._queries), 0)
+
+    async def test_ddt_models_untracking_async(self):
+        self.assertEqual(len(self.panel._queries), 0)
+
+        # enable ddt tracking
+        sql_tracking.allow_ddt_models_tracking.set(False)
+
+        await async_sql_call_ddt()
+
+        self.assertEqual(len(self.panel._queries), 0)
 
     @unittest.skipUnless(
         connection.vendor == "postgresql", "Test valid only on PostgreSQL"


### PR DESCRIPTION
#### Description

Added a new context variable `allow_ddt_models_tracking` to control whether  `SQLPanel` tracks *DDT* queries.

- Added `allow_ddt_models_tracking` contextvar, defaulting to `False`
- `SQLPanel` now checks this variable to decide if *DDT* models queries should be tracked.

Fixes #2165 

#### Checklist:

- [x] I have added the relevant tests for this change.
- [ ] I have added an item to the Pending section of ``docs/changes.rst``.
