### PR TITLE
Fix django unicode error

### DIFF
--- a/debug_toolbar/panels/settings.py
+++ b/debug_toolbar/panels/settings.py
@@ -1,6 +1,7 @@
 from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
 from django.views.debug import get_default_exception_reporter_filter
+from django.utils.encoding import DjangoUnicodeDecodeError
 
 from debug_toolbar.panels import Panel
 
@@ -24,10 +25,17 @@ class SettingsPanel(Panel):
         )
 
     def generate_stats(self, request, response):
+
+        def catch_force_errors(force_function, value):
+            try:
+                return force_function(value)
+            except DjangoUnicodeDecodeError:
+                return 'Debug toolbar was unable to parse value'
+
         self.record_stats(
             {
                 "settings": {
-                    key: force_str(value)
+                    key: catch_force_errors(force_str, value)
                     for key, value in sorted(get_safe_settings().items())
                 }
             }

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -13,6 +13,8 @@ Pending
   class instance, regardless if any data was generated.
 * Fixed selenium tests for CI by using psycopg for Python 3.13 runs.
 * Added ``CommunityPanel`` containing links to documentation and resources.
+* Fixed force_str to catch error and give out degault string if value is not
+  serializable
 
 6.0.0 (2025-07-22)
 ------------------

--- a/tests/panels/test_settings.py
+++ b/tests/panels/test_settings.py
@@ -3,7 +3,7 @@ from django.test import override_settings
 from ..base import IntegrationTestCase
 
 
-@override_settings(DEBUG=True)
+@override_settings(DEBUG=True, RANDOM_SETTING=bytes.fromhex("a3f2b8c14e972d5a8fb3c7291a64e0859c472bf63d18a0945e73b2c84f917ae2"))
 class SettingsIntegrationTestCase(IntegrationTestCase):
     def test_panel_title(self):
         response = self.client.get("/regular/basic/")


### PR DESCRIPTION
#### Description

The force serialize function in [django-debug-toolbar/debug_toolbar/panels/settings.py] was throwing errors for values that are not serializable. The proposed solution returns the serialized value if the value is serializable or returns 'Debug toolbar was unable to parse value'

Fixes # (issue)

#### Checklist:

- [ X] I have added the relevant tests for this change.
- [ X] I have added an item to the Pending section of ``docs/changes.rst``.
