### PR TITLE
Treat some warnings as errors in CI

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -21,6 +21,8 @@ Pending
   limits. When ``SQLParseError`` is raised, the SQL panel now automatically
   disables grouping and retries formatting, preventing crashes with large
   queries.
+* Updated tox configuration to treat ``DeprecationWarning``,
+  ``ResourceWarning``, and ``PendingDeprecationWarning`` as errors.
 
 6.3.0 (2026-04-01)
 ------------------

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,13 @@ passenv=
     GITHUB_*
 setenv =
     PYTHONPATH = {toxinidir}
-    PYTHONWARNINGS = d
+    PYTHONWARNINGS =\
+        error::ResourceWarning,\
+        error::DeprecationWarning,\
+        error::PendingDeprecationWarning,\
+        ignore:The RedirectsPanel is deprecated:DeprecationWarning,\
+        # This can be removed when we're fully to 6.0
+        ignore:The 'partial'and 'partialdef' template tags are now part of Django core:DeprecationWarning
     DB_NAME = {env:DB_NAME:debug_toolbar}
     DB_USER = {env:DB_USER:debug_toolbar}
     DB_HOST = {env:DB_HOST:localhost}
@@ -43,7 +49,7 @@ allowlist_externals = make
 pip_pre = True
 dependency_groups =
     dev
-commands = python -b -W always -m coverage run -m django test -v2 {posargs:tests}
+commands = python -b -m coverage run -m django test -v2 {posargs:tests}
 
 
 [testenv:py{310,311,312,313,314}-dj{52,60,main}-{postgresql,psycopg3}]


### PR DESCRIPTION
#### Description

Explicitly ignores the RedirectPanel's deprecation warning.

#### Checklist:

- [x] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.
