### PR TITLE
Add graceful degradation for large SQL queries

### DIFF
--- a/debug_toolbar/panels/sql/utils.py
+++ b/debug_toolbar/panels/sql/utils.py
@@ -9,6 +9,13 @@ from sqlparse import tokens as T
 
 from debug_toolbar import settings as dt_settings
 
+# Import SQLParseError for graceful exception handling
+try:
+    from sqlparse.exceptions import SQLParseError
+except ImportError:
+    # Older sqlparse versions don't have this exception
+    SQLParseError = None
+
 
 class ElideSelectListsFilter:
     """sqlparse filter to elide the select list from top-level SELECT ... FROM clauses,
@@ -92,11 +99,59 @@ def is_select_query(sql):
     return sql.lower().lstrip(" (").startswith("select")
 
 
+def _format_skipped_sql(sql, reason):
+    """
+    Format SQL that was skipped from prettification.
+
+    Shows a notice and the first portion of raw SQL for debugging.
+    """
+    preview_length = 500
+    preview = escape(sql[:preview_length])
+    total_length = len(sql)
+
+    if total_length > preview_length:
+        suffix = f"\n\n... ({total_length - preview_length:,} more characters)"
+    else:
+        suffix = ""
+
+    return (
+        f'<span class="djdt-sql-skipped">'
+        f"<em>SQL formatting skipped ({reason})</em>"
+        f"</span>"
+        f"<pre>{escape(preview)}{suffix}</pre>"
+    )
+
+
 def reformat_sql(sql, *, with_toggle=False):
-    formatted = parse_sql(sql)
-    if not with_toggle:
-        return formatted
-    simplified = parse_sql(sql, simplify=True)
+    # Check length threshold to prevent slow formatting of large queries
+    max_length = dt_settings.get_config()["SQL_PRETTIFY_MAX_LENGTH"]
+    if max_length and len(sql) > max_length:
+        skipped = _format_skipped_sql(
+            sql,
+            f"query length {len(sql):,} exceeds threshold {max_length:,}",
+        )
+        if with_toggle:
+            # Return as non-collapsible since both versions would be the same
+            return f'<span class="djDebugUncollapsed">{skipped}</span>'
+        return skipped
+
+    try:
+        formatted = parse_sql(sql)
+        if not with_toggle:
+            return formatted
+        simplified = parse_sql(sql, simplify=True)
+    except Exception as e:
+        # Handle sqlparse exceptions (e.g., MAX_GROUPING_TOKENS exceeded in >= 0.5.5)
+        if SQLParseError is not None and isinstance(e, SQLParseError):
+            reason = f"sqlparse error: {e}"
+        else:
+            # Re-raise unexpected exceptions
+            raise
+        skipped = _format_skipped_sql(sql, reason)
+        if with_toggle:
+            return f'<span class="djDebugUncollapsed">{skipped}</span>'
+        return skipped
+
     uncollapsed = f'<span class="djDebugUncollapsed">{simplified}</span>'
     collapsed = f'<span class="djDebugCollapsed djdt-hidden">{formatted}</span>'
     return collapsed + uncollapsed

--- a/debug_toolbar/panels/sql/utils.py
+++ b/debug_toolbar/panels/sql/utils.py
@@ -6,6 +6,7 @@ import sqlparse
 from django.dispatch import receiver
 from django.test.signals import setting_changed
 from sqlparse import tokens as T
+from sqlparse.exceptions import SQLParseError
 
 from debug_toolbar import settings as dt_settings
 
@@ -92,42 +93,7 @@ def is_select_query(sql):
     return sql.lower().lstrip(" (").startswith("select")
 
 
-def _format_skipped_sql(sql, reason):
-    """
-    Format SQL that was skipped from prettification.
-
-    Shows a notice and the first portion of raw SQL for debugging.
-    """
-    preview_length = 500
-    preview = escape(sql[:preview_length])
-    total_length = len(sql)
-
-    if total_length > preview_length:
-        suffix = f"\n\n... ({total_length - preview_length:,} more characters)"
-    else:
-        suffix = ""
-
-    return (
-        f'<span class="djdt-sql-skipped">'
-        f"<em>SQL formatting skipped ({reason})</em>"
-        f"</span>"
-        f"<pre>{preview}{suffix}</pre>"
-    )
-
-
 def reformat_sql(sql, *, with_toggle=False):
-    # Check length threshold to prevent slow formatting of large queries
-    max_length = dt_settings.get_config()["SQL_PRETTIFY_MAX_LENGTH"]
-    if max_length and len(sql) > max_length:
-        skipped = _format_skipped_sql(
-            sql,
-            f"query length {len(sql):,} exceeds threshold {max_length:,}",
-        )
-        if with_toggle:
-            # Return as non-collapsible since both versions would be the same
-            return f'<span class="djDebugUncollapsed">{skipped}</span>'
-        return skipped
-
     formatted = parse_sql(sql)
     if not with_toggle:
         return formatted
@@ -141,7 +107,15 @@ def reformat_sql(sql, *, with_toggle=False):
 @lru_cache(maxsize=128)
 def parse_sql(sql, *, simplify=False):
     stack = get_filter_stack(simplify=simplify)
-    return "".join(stack.run(sql))
+    try:
+        return "".join(stack.run(sql))
+    except SQLParseError:
+        # The query either exceeds the number of tokens or depth of tokens.
+        # Recreate the FilterStack and explicitly disable the grouping to avoid
+        # those errors.
+        stack = get_filter_stack(simplify=simplify)
+        stack._grouping = False
+        return "".join(stack.run(sql))
 
 
 @cache

--- a/debug_toolbar/panels/sql/utils.py
+++ b/debug_toolbar/panels/sql/utils.py
@@ -9,13 +9,6 @@ from sqlparse import tokens as T
 
 from debug_toolbar import settings as dt_settings
 
-# Import SQLParseError for graceful exception handling
-try:
-    from sqlparse.exceptions import SQLParseError
-except ImportError:
-    # Older sqlparse versions don't have this exception
-    SQLParseError = None
-
 
 class ElideSelectListsFilter:
     """sqlparse filter to elide the select list from top-level SELECT ... FROM clauses,
@@ -135,22 +128,10 @@ def reformat_sql(sql, *, with_toggle=False):
             return f'<span class="djDebugUncollapsed">{skipped}</span>'
         return skipped
 
-    try:
-        formatted = parse_sql(sql)
-        if not with_toggle:
-            return formatted
-        simplified = parse_sql(sql, simplify=True)
-    except Exception as e:
-        # Handle sqlparse exceptions (e.g., MAX_GROUPING_TOKENS exceeded in >= 0.5.5)
-        if SQLParseError is not None and isinstance(e, SQLParseError):
-            reason = f"sqlparse error: {e}"
-        else:
-            # Re-raise unexpected exceptions
-            raise
-        skipped = _format_skipped_sql(sql, reason)
-        if with_toggle:
-            return f'<span class="djDebugUncollapsed">{skipped}</span>'
-        return skipped
+    formatted = parse_sql(sql)
+    if not with_toggle:
+        return formatted
+    simplified = parse_sql(sql, simplify=True)
 
     uncollapsed = f'<span class="djDebugUncollapsed">{simplified}</span>'
     collapsed = f'<span class="djDebugCollapsed djdt-hidden">{formatted}</span>'

--- a/debug_toolbar/panels/sql/utils.py
+++ b/debug_toolbar/panels/sql/utils.py
@@ -118,7 +118,7 @@ def _format_skipped_sql(sql, reason):
         f'<span class="djdt-sql-skipped">'
         f"<em>SQL formatting skipped ({reason})</em>"
         f"</span>"
-        f"<pre>{escape(preview)}{suffix}</pre>"
+        f"<pre>{preview}{suffix}</pre>"
     )
 
 

--- a/debug_toolbar/settings.py
+++ b/debug_toolbar/settings.py
@@ -53,7 +53,6 @@ CONFIG_DEFAULTS = {
         "django.utils.functional",
     ),
     "PRETTIFY_SQL": True,
-    "SQL_PRETTIFY_MAX_LENGTH": 50000,  # Skip formatting for SQL longer than this
     "PROFILER_CAPTURE_PROJECT_CODE": True,
     "PROFILER_MAX_DEPTH": 10,
     "PROFILER_THRESHOLD_RATIO": 8,

--- a/debug_toolbar/settings.py
+++ b/debug_toolbar/settings.py
@@ -53,6 +53,7 @@ CONFIG_DEFAULTS = {
         "django.utils.functional",
     ),
     "PRETTIFY_SQL": True,
+    "SQL_PRETTIFY_MAX_LENGTH": 50000,  # Skip formatting for SQL longer than this
     "PROFILER_CAPTURE_PROJECT_CODE": True,
     "PROFILER_MAX_DEPTH": 10,
     "PROFILER_THRESHOLD_RATIO": 8,

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -3,6 +3,7 @@ Change log
 
 Pending
 -------
+
 * Prevent check from failing when ``ROOT_URLCONF`` is not defined.
 * Prevent debounce race conditions in the history panel for rapid
   fetch requests.
@@ -16,6 +17,10 @@ Pending
   those overrides to ``#djDebug``, and custom panels that rely on external
   styles or DOM lookups reaching into the toolbar will need updates to
   work with the shadow DOM.
+* Added graceful degradation for SQL queries that exceed sqlparse's token
+  limits. When ``SQLParseError`` is raised, the SQL panel now automatically
+  disables grouping and retries formatting, preventing crashes with large
+  queries.
 
 6.3.0 (2026-04-01)
 ------------------
@@ -44,10 +49,6 @@ Pending
 6.2.0 (2026-01-20)
 ------------------
 
-* Added graceful degradation for SQL queries that exceed sqlparse's token
-  limits. When ``SQLParseError`` is raised, the SQL panel now automatically
-  disables grouping and retries formatting, preventing crashes with large
-  queries.
 * Deprecated ``RedirectsPanel`` in favor of ``HistoryPanel`` for viewing
   toolbar data from redirected requests.
 * Fixed support for generating code coverage comments in PRs.

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -44,6 +44,10 @@ Pending
 6.2.0 (2026-01-20)
 ------------------
 
+* Added ``SQL_PRETTIFY_MAX_LENGTH`` setting to skip SQL formatting for
+  queries exceeding the threshold. This prevents the SQL panel from freezing
+  or crashing when queries contain large IN clauses with thousands of
+  parameters.
 * Deprecated ``RedirectsPanel`` in favor of ``HistoryPanel`` for viewing
   toolbar data from redirected requests.
 * Fixed support for generating code coverage comments in PRs.

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -44,10 +44,10 @@ Pending
 6.2.0 (2026-01-20)
 ------------------
 
-* Added ``SQL_PRETTIFY_MAX_LENGTH`` setting to skip SQL formatting for
-  queries exceeding the threshold. This prevents the SQL panel from freezing
-  or crashing when queries contain large IN clauses with thousands of
-  parameters.
+* Added graceful degradation for SQL queries that exceed sqlparse's token
+  limits. When ``SQLParseError`` is raised, the SQL panel now automatically
+  disables grouping and retries formatting, preventing crashes with large
+  queries.
 * Deprecated ``RedirectsPanel`` in favor of ``HistoryPanel`` for viewing
   toolbar data from redirected requests.
 * Fixed support for generating code coverage comments in PRs.

--- a/tests/panels/test_sql.py
+++ b/tests/panels/test_sql.py
@@ -885,9 +885,11 @@ class SQLPanelTestCase(BaseTestCase):
         self.assertIn("SELECT", result)
 
         # Long SQL should skip formatting and show a message
-        long_sql = "SELECT * FROM auth_user WHERE id IN (" + ", ".join(
-            [f"'{i}'" for i in range(100)]
-        ) + ")"
+        long_sql = (
+            "SELECT * FROM auth_user WHERE id IN ("
+            + ", ".join([f"'{i}'" for i in range(100)])
+            + ")"
+        )
         result = reformat_sql(long_sql, with_toggle=True)
         self.assertIn("SQL formatting skipped", result)
         self.assertIn("exceeds threshold", result)
@@ -898,9 +900,11 @@ class SQLPanelTestCase(BaseTestCase):
         """
         from debug_toolbar.panels.sql.utils import reformat_sql
 
-        long_sql = "SELECT * FROM auth_user WHERE id IN (" + ", ".join(
-            [f"'{i}'" for i in range(100)]
-        ) + ")"
+        long_sql = (
+            "SELECT * FROM auth_user WHERE id IN ("
+            + ", ".join([f"'{i}'" for i in range(100)])
+            + ")"
+        )
 
         with override_settings(
             DEBUG_TOOLBAR_CONFIG={"SQL_PRETTIFY_MAX_LENGTH": 0, "PRETTIFY_SQL": True}

--- a/tests/panels/test_sql.py
+++ b/tests/panels/test_sql.py
@@ -895,9 +895,7 @@ class SQLPanelTestCase(BaseTestCase):
             # On retry, return a simple result
             return [sql]
 
-        with patch(
-            "debug_toolbar.panels.sql.utils.get_filter_stack"
-        ) as mock_get_stack:
+        with patch("debug_toolbar.panels.sql.utils.get_filter_stack") as mock_get_stack:
             mock_stack = mock_get_stack.return_value
             mock_stack.run = mock_run
             mock_stack._grouping = True

--- a/tests/panels/test_sql.py
+++ b/tests/panels/test_sql.py
@@ -19,6 +19,8 @@ import debug_toolbar.panels.sql.tracking as sql_tracking
 from debug_toolbar import settings as dt_settings
 from debug_toolbar.models import HistoryEntry
 from debug_toolbar.panels.sql import SQLPanel, tracking
+from debug_toolbar.panels.sql.utils import parse_sql
+from sqlparse.exceptions import SQLParseError
 
 try:
     import psycopg
@@ -874,41 +876,26 @@ class SQLPanelTestCase(BaseTestCase):
         """
         Test that SQLParseError is handled gracefully by disabling grouping.
         """
-        from unittest.mock import patch
-
-        from sqlparse.exceptions import SQLParseError
-
-        from debug_toolbar.panels.sql.utils import parse_sql
-
-        # Clear the cache to ensure our mock is used
         parse_sql.cache_clear()
 
-        # Mock the filter stack to raise SQLParseError on first call
-        call_count = 0
-        original_run = None
-
-        def mock_run(sql):
-            nonlocal call_count, original_run
-            call_count += 1
-            if call_count == 1:
+        def run_side_effect(sql):
+            if mock_stack.run.call_count == 1:
                 raise SQLParseError("Token limit exceeded")
-            # On retry, return a simple result
             return [sql]
 
         with patch("debug_toolbar.panels.sql.utils.get_filter_stack") as mock_get_stack:
             mock_stack = mock_get_stack.return_value
-            mock_stack.run = mock_run
+            mock_stack.run.side_effect = run_side_effect
             mock_stack._grouping = True
 
             result = parse_sql("SELECT * FROM test")
 
             # Should have been called twice (once for error, once for retry)
-            self.assertEqual(call_count, 2)
+            self.assertEqual(mock_stack.run.call_count, 2)
             # On retry, _grouping should be set to False
             self.assertFalse(mock_stack._grouping)
             self.assertIn("SELECT", result)
 
-        # Clear the cache after the test
         parse_sql.cache_clear()
 
 

--- a/tests/panels/test_sql.py
+++ b/tests/panels/test_sql.py
@@ -14,13 +14,13 @@ from django.db.models import Count
 from django.db.utils import DatabaseError
 from django.shortcuts import render
 from django.test.utils import override_settings
+from sqlparse.exceptions import SQLParseError
 
 import debug_toolbar.panels.sql.tracking as sql_tracking
 from debug_toolbar import settings as dt_settings
 from debug_toolbar.models import HistoryEntry
 from debug_toolbar.panels.sql import SQLPanel, tracking
 from debug_toolbar.panels.sql.utils import parse_sql
-from sqlparse.exceptions import SQLParseError
 
 try:
     import psycopg


### PR DESCRIPTION
#### Description

Add graceful degradation for SQL queries that exceed sqlparse's token limits, preventing crashes in the SQL panel.

**Problem:**
When SQL queries contain thousands of parameters (e.g., UUIDs in IN clauses), the SQL panel crashes with `SQLParseError` (sqlparse >= 0.5.5).

**Solution:**
Catch `SQLParseError` and retry formatting with grouping disabled. This approach:
- Handles the crash automatically without requiring configuration
- Eliminates the need for a new setting like `SQL_PRETTIFY_MAX_LENGTH`

**Out of scope:** The freezing behavior with older sqlparse versions (< 0.5.5) is a pre-existing issue and not addressed in this PR.

**Before (debug-toolbar 5.2 + sqlparse 0.5.3) - page freezes (out of scope):**

![before-page-freeze](https://github.com/user-attachments/assets/f53d0eb5-7ef5-42e9-ac96-2bc1372adfed)

**Before (debug-toolbar 6.1 + sqlparse 0.5.5) - SQLParseError:**

![before-sqlparse-error](https://github.com/user-attachments/assets/1b99e369-f0b5-4dab-a429-5f2f65889464)

**After (this PR):**

![after-fix](https://github.com/user-attachments/assets/2f165563-c681-48a5-8fca-7ebd757f9461)

**Reproduction project:** https://github.com/kkm-horikawa/debug-toolbar-perf-issue

Fixes #2293

#### Checklist:

- [x] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.