### PR TITLE
Update JS syntax to Baseline 2025 using esupgrade

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,10 @@ repos:
     hooks:
     -   id: django-upgrade
         args: [--target-version, "4.2"]
+-   repo: https://github.com/codingjoe/esupgrade
+    rev: 2025.15.0
+    hooks:
+    -   id: esupgrade
 -   repo: https://github.com/adamchainz/djade-pre-commit
     rev: "1.9.0"
     hooks:

--- a/debug_toolbar/static/debug_toolbar/js/toolbar.js
+++ b/debug_toolbar/static/debug_toolbar/js/toolbar.js
@@ -43,7 +43,7 @@ const djdt = {
                 if (requestId && inner.children.length === 0) {
                     const url = new URL(
                         djDebug.dataset.renderPanelUrl,
-                        window.location
+                        globalThis.location
                     );
                     url.searchParams.append("request_id", requestId);
                     url.searchParams.append("panel_id", panelId);
@@ -166,8 +166,8 @@ const djdt = {
 
                 if (top < 0) {
                     top = 0;
-                } else if (top + handle.offsetHeight > window.innerHeight) {
-                    top = window.innerHeight - handle.offsetHeight;
+                } else if (top + handle.offsetHeight > globalThis.innerHeight) {
+                    top = globalThis.innerHeight - handle.offsetHeight;
                 }
 
                 handle.style.top = `${top}px`;
@@ -212,19 +212,20 @@ const djdt = {
             djdt.updateOnAjax();
         }
 
-        const prefersDark = window.matchMedia(
+        const prefersDark = globalThis.matchMedia(
             "(prefers-color-scheme: dark)"
         ).matches;
         const themeList = prefersDark
             ? ["auto", "light", "dark"]
             : ["auto", "dark", "light"];
-        const setTheme = (theme) => {
+
+        function setTheme(theme) {
             djDebug.setAttribute(
                 "data-theme",
                 theme === "auto" ? (prefersDark ? "dark" : "light") : theme
             );
             djDebug.setAttribute("data-user-theme", theme);
-        };
+        }
 
         // Updates the theme using user settings
         let userTheme = localStorage.getItem("djdt.user-theme") || "auto";
@@ -253,7 +254,7 @@ const djdt = {
         // set handle position
         const handleTop = Math.min(
             localStorage.getItem("djdt.top") || 265,
-            window.innerHeight - handle.offsetWidth
+            globalThis.innerHeight - handle.offsetWidth
         );
         handle.style.top = `${handleTop}px`;
     },
@@ -265,7 +266,7 @@ const djdt = {
         const handle = document.getElementById("djDebugToolbarHandle");
         $$.show(handle);
         djdt.ensureHandleVisibility();
-        window.addEventListener("resize", djdt.ensureHandleVisibility);
+        globalThis.addEventListener("resize", djdt.ensureHandleVisibility);
         document.removeEventListener("keydown", onKeyDown);
 
         localStorage.setItem("djdt.show", "false");
@@ -289,7 +290,7 @@ const djdt = {
         $$.hide(document.getElementById("djDebugToolbarHandle"));
         $$.show(document.getElementById("djDebugToolbar"));
         localStorage.setItem("djdt.show", "true");
-        window.removeEventListener("resize", djdt.ensureHandleVisibility);
+        globalThis.removeEventListener("resize", djdt.ensureHandleVisibility);
     },
     updateOnAjax() {
         const handleAjaxResponse = debounce(async (requestId) => {
@@ -328,8 +329,8 @@ const djdt = {
             origOpen.apply(this, args);
         };
 
-        const origFetch = window.fetch;
-        window.fetch = function (...args) {
+        const origFetch = globalThis.fetch;
+        globalThis.fetch = function (...args) {
             // Heads up! Before modifying this code, please be aware of the
             // possible unhandled errors that might arise from changing this.
             // For details, see
@@ -384,7 +385,7 @@ const djdt = {
         },
     },
 };
-window.djdt = {
+globalThis.djdt = {
     show_toolbar: djdt.showToolbar,
     hide_toolbar: djdt.hideToolbar,
     init: djdt.init,

--- a/debug_toolbar/static/debug_toolbar/js/utils.js
+++ b/debug_toolbar/static/debug_toolbar/js/utils.js
@@ -72,24 +72,20 @@ const $$ = {
 
 async function ajax(url, init) {
     try {
-        const response = await fetch(
-            url,
-            Object.assign({ credentials: "same-origin" }, init)
-        );
+        const response = await fetch(url, {
+            credentials: "same-origin",
+            ...init,
+        });
         if (response.ok) {
-            return response
-                .json()
-                .catch((error) =>
-                    Promise.reject(
-                        new Error(
-                            `The response  is a invalid Json object : ${error}`
-                        )
-                    )
+            try {
+                return response.json();
+            } catch (error) {
+                throw new Error(
+                    u`The response is a invalid Json object : ${error}`
                 );
+            }
         }
-        return Promise.reject(
-            new Error(`${response.status}: ${response.statusText}`)
-        );
+        throw new Error(`${response.status}: ${response.statusText}`);
     } catch (error) {
         const win = document.getElementById("djDebugWindow");
         win.innerHTML = `<div class="djDebugPanelTitle"><h3>${error.message}</h3><button type="button" class="djDebugClose">»</button></div>`;

--- a/debug_toolbar/static/debug_toolbar/js/utils.js
+++ b/debug_toolbar/static/debug_toolbar/js/utils.js
@@ -70,6 +70,21 @@ export const $$ = {
     },
 };
 
+/**
+ * Fetch the debug element from the DOM.
+ *
+ * This is used to avoid writing the element's id everywhere the element
+ * is being selected. A fixed reference to the element should be avoided
+ * because the entire DOM could be reloaded such as via HTMX boosting.
+ */
+function getDebugElement() {
+    let root = document.getElementById("djDebugRoot");
+    if (root.shadowRoot) {
+        root = root.shadowRoot;
+    }
+    return root.querySelector("#djDebug");
+}
+
 export async function ajax(url, init) {
     try {
         const response = await fetch(url, {
@@ -92,21 +107,6 @@ export async function ajax(url, init) {
         $$.show(win);
         throw error;
     }
-}
-
-/**
- * Fetch the debug element from the DOM.
- *
- * This is used to avoid writing the element's id everywhere the element
- * is being selected. A fixed reference to the element should be avoided
- * because the entire DOM could be reloaded such as via HTMX boosting.
- */
-function getDebugElement() {
-    let root = document.getElementById("djDebugRoot");
-    if (root.shadowRoot) {
-        root = root.shadowRoot;
-    }
-    return root.querySelector("#djDebug");
 }
 
 export function ajaxForm(element) {

--- a/debug_toolbar/static/debug_toolbar/js/utils.js
+++ b/debug_toolbar/static/debug_toolbar/js/utils.js
@@ -1,4 +1,4 @@
-const $$ = {
+export const $$ = {
     on(root, eventName, selector, fn) {
         root.removeEventListener(eventName, fn);
         root.addEventListener(eventName, (event) => {
@@ -70,7 +70,7 @@ const $$ = {
     },
 };
 
-async function ajax(url, init) {
+export async function ajax(url, init) {
     try {
         const response = await fetch(url, {
             credentials: "same-origin",
@@ -81,7 +81,7 @@ async function ajax(url, init) {
                 return response.json();
             } catch (error) {
                 throw new Error(
-                    u`The response is a invalid Json object : ${error}`
+                    `The response is a invalid Json object : ${error}`
                 );
             }
         }
@@ -94,7 +94,7 @@ async function ajax(url, init) {
     }
 }
 
-function ajaxForm(element) {
+export function ajaxForm(element) {
     const form = element.closest("form");
     const url = new URL(form.action);
     const formData = new FormData(form);
@@ -107,7 +107,7 @@ function ajaxForm(element) {
     return ajax(url, ajaxData);
 }
 
-function replaceToolbarState(newRequestId, data) {
+export function replaceToolbarState(newRequestId, data) {
     const djDebug = document.getElementById("djDebug");
     djDebug.setAttribute("data-request-id", newRequestId);
     // Check if response is empty, it could be due to an expired requestId.
@@ -137,5 +137,3 @@ export function debounce(func, timeout) {
         timer = setTimeout(() => Promise.try(func, ...args), timeout);
     };
 }
-
-export { $$, ajax, ajaxForm, replaceToolbarState };

--- a/debug_toolbar/static/debug_toolbar/js/utils.js
+++ b/debug_toolbar/static/debug_toolbar/js/utils.js
@@ -70,30 +70,32 @@ const $$ = {
     },
 };
 
-function ajax(url, init) {
-    return fetch(url, Object.assign({ credentials: "same-origin" }, init))
-        .then((response) => {
-            if (response.ok) {
-                return response
-                    .json()
-                    .catch((error) =>
-                        Promise.reject(
-                            new Error(
-                                `The response  is a invalid Json object : ${error}`
-                            )
+async function ajax(url, init) {
+    try {
+        const response = await fetch(
+            url,
+            Object.assign({ credentials: "same-origin" }, init)
+        );
+        if (response.ok) {
+            return response
+                .json()
+                .catch((error) =>
+                    Promise.reject(
+                        new Error(
+                            `The response  is a invalid Json object : ${error}`
                         )
-                    );
-            }
-            return Promise.reject(
-                new Error(`${response.status}: ${response.statusText}`)
-            );
-        })
-        .catch((error) => {
-            const win = document.getElementById("djDebugWindow");
-            win.innerHTML = `<div class="djDebugPanelTitle"><h3>${error.message}</h3><button type="button" class="djDebugClose">»</button></div>`;
-            $$.show(win);
-            throw error;
-        });
+                    )
+                );
+        }
+        return Promise.reject(
+            new Error(`${response.status}: ${response.statusText}`)
+        );
+    } catch (error) {
+        const win = document.getElementById("djDebugWindow");
+        win.innerHTML = `<div class="djDebugPanelTitle"><h3>${error.message}</h3><button type="button" class="djDebugClose">»</button></div>`;
+        $$.show(win);
+        throw error;
+    }
 }
 
 function ajaxForm(element) {

--- a/debug_toolbar/static/debug_toolbar/js/utils.js
+++ b/debug_toolbar/static/debug_toolbar/js/utils.js
@@ -8,15 +8,15 @@ const $$ = {
             }
         });
     },
+    /**
+     * This is a helper function to attach a handler for a `djdt.panel.render`
+     * event of a specific panel.
+     *
+     * root: The container element that the listener should be attached to.
+     * panelId: The Id of the panel.
+     * fn: A function to execute when the event is triggered.
+     */
     onPanelRender(root, panelId, fn) {
-        /*
-        This is a helper function to attach a handler for a `djdt.panel.render`
-        event of a specific panel.
-
-        root: The container element that the listener should be attached to.
-        panelId: The Id of the panel.
-        fn: A function to execute when the event is triggered.
-         */
         root.addEventListener("djdt.panel.render", (event) => {
             if (event.detail.panelId === panelId) {
                 fn.call(event);
@@ -48,12 +48,12 @@ const $$ = {
             document.head.appendChild(el);
         }
     },
+    /**
+     * Given a container element, apply styles set via data-djdt-styles attribute.
+     * The format is data-djdt-styles="styleName1:value;styleName2:value2"
+     * The style names should use the CSSStyleDeclaration camel cased names.
+     */
     applyStyles(container) {
-        /*
-         * Given a container element, apply styles set via data-djdt-styles attribute.
-         * The format is data-djdt-styles="styleName1:value;styleName2:value2"
-         * The style names should use the CSSStyleDeclaration camel cased names.
-         */
         for (const element of container.querySelectorAll(
             "[data-djdt-styles]"
         )) {

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -8,6 +8,8 @@ Pending
   fetch requests.
 * Added a note to the prerequisites section of the installation docs
   about requiring an up-to-date browser.
+* Upgraded the JavaScript code to use modern ECMAScript features using
+  ``esupgrade``.
 
 6.3.0 (2026-04-01)
 ------------------


### PR DESCRIPTION
#### Description

I was browsing through the JS code and stumbled upon dated syntax. Since I wrote a tool for it, I ran it. However, I added more commits to manually address some discrepancies.

#### Checklist:

- [x] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.

#### AI/LLM Usage
- [x] This PR includes code generated with the help of an AI/LLM

> I got some LLM powered autocomplete help while writing the tests.
