### PR TITLE
Refs #2356: Add a note to the prerequisites section about requiring a modern browser

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -6,6 +6,8 @@ Pending
 * Prevent check from failing when ``ROOT_URLCONF`` is not defined.
 * Prevent debounce race conditions in the history panel for rapid
   fetch requests.
+* Added a note to the prerequisites section of the installation docs
+  about requiring an up-to-date browser.
 
 6.3.0 (2026-04-01)
 ------------------

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -70,8 +70,10 @@ Second, ensure that your ``TEMPLATES`` setting contains a
         }
     ]
 
-Third, the Debug Toolbar requires an up to date browser and targets [Baseline Newly Available](https://web.dev/series/baseline-newly-available) to delivery modern debug tools. Should you need to test in an
-older browser, simply disable the toolbar for those sessions.
+Third, the Debug Toolbar requires an up to date browser and targets [Baseline
+Newly Available](https://web.dev/series/baseline-newly-available) to delivery
+modern debug tools. Should you need to test in an older browser, simply disable
+the toolbar for those sessions.
 
 3. Install the App
 ^^^^^^^^^^^^^^^^^^

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -70,6 +70,10 @@ Second, ensure that your ``TEMPLATES`` setting contains a
         }
     ]
 
+Third, the Debug Toolbar requires a modern browser. Since the toolbar is a
+development tool, this is generally not an issue — if you need to test in an
+older browser, simply disable the toolbar for that session.
+
 3. Install the App
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -70,9 +70,8 @@ Second, ensure that your ``TEMPLATES`` setting contains a
         }
     ]
 
-Third, the Debug Toolbar requires a modern browser. Since the toolbar is a
-development tool, this is generally not an issue — if you need to test in an
-older browser, simply disable the toolbar for that session.
+Third, the Debug Toolbar requires an up to date browser and targets [Baseline Newly Available](https://web.dev/series/baseline-newly-available) to delivery modern debug tools. Should you need to test in an
+older browser, simply disable the toolbar for those sessions.
 
 3. Install the App
 ^^^^^^^^^^^^^^^^^^

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -27,6 +27,7 @@ flatpages
 frontend
 htmx
 inlining
+instantiation
 instrumentation
 isort
 jQuery


### PR DESCRIPTION
#### Description

We have introduced `Promise.try` in #2356 and therefore should state clearly that we expect developers to have an up-to-date browser for using the toolbar.

#### Checklist:

- [ ] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.

#### AI/LLM Usage
- [x] This PR includes code generated with the help of an AI/LLM
