### PR TITLE
Drop Promise.try and change documented Baseline target to Widely-Available

### DIFF
--- a/debug_toolbar/static/debug_toolbar/js/utils.js
+++ b/debug_toolbar/static/debug_toolbar/js/utils.js
@@ -136,7 +136,7 @@ export function debounce(func, timeout) {
     let timer;
     return (...args) => {
         clearTimeout(timer);
-        timer = setTimeout(() => Promise.try(func, ...args), timeout);
+        timer = setTimeout(() => func(...args), timeout);
     };
 }
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -71,7 +71,7 @@ Second, ensure that your ``TEMPLATES`` setting contains a
     ]
 
 Third, the Debug Toolbar requires an up to date browser and targets [Baseline
-Newly Available](https://web.dev/series/baseline-newly-available) to delivery
+Widely Available](https://web.dev/series/baseline-widely-available) to delivery
 modern debug tools. Should you need to test in an older browser, simply disable
 the toolbar for those sessions.
 


### PR DESCRIPTION
#### Description

Why do this work?: In short, in JavaScript, promises (like an async function) don't need to be awaited to be executed.

Ref f9e1b585fb9c1ed17e8f06b669b5dc282e8ad063
Ref #2357

#### Checklist:

- [x] I have added the relevant tests for this change.
- [ ] I have added an item to the Pending section of ``docs/changes.rst``.

#### AI/LLM Usage
- [ ] This PR includes code generated with the help of an AI/LLM
