### PR TITLE
Clarified configuration documentation about SHOW_TOOLBAR_CALLBACK

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -25,6 +25,9 @@ Pending
   ``esupgrade``.
 * Updated tox configuration to treat ``DeprecationWarning``,
   ``ResourceWarning``, and ``PendingDeprecationWarning`` as errors.
+* Clarified configuration documentation about ``SHOW_TOOLBAR_CALLBACK``
+  needing to respect ``django.conf.settings.DEBUG`` to match
+  ``debug_toolbar_urls``.
 
 6.3.0 (2026-04-01)
 ------------------

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -179,6 +179,10 @@ Toolbar options
   provide your own function ``callback(request)`` which returns ``True`` or
   ``False``.
 
+  If implementing a custom function and using the
+  ``debug_toolbar.toolbar.debug_toolbar_urls`` to inject the toolbar's paths,
+  this callback must return ``False`` when ``django.conf.settings.DEBUG``.
+
   For versions < 1.8, the callback should also return ``False`` for AJAX
   requests. Since version 1.8, AJAX requests are checked in the middleware, not
   the callback. This allows reusing the callback to verify access to panel

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -181,7 +181,7 @@ Toolbar options
 
   If implementing a custom function and using the
   ``debug_toolbar.toolbar.debug_toolbar_urls`` to inject the toolbar's paths,
-  this callback must return ``False`` when ``django.conf.settings.DEBUG``.
+  this callback must return ``False`` when ``django.conf.settings.DEBUG`` is ``False``.
 
   For versions < 1.8, the callback should also return ``False`` for AJAX
   requests. Since version 1.8, AJAX requests are checked in the middleware, not

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -181,7 +181,8 @@ Toolbar options
 
   If implementing a custom function and using the
   ``debug_toolbar.toolbar.debug_toolbar_urls`` to inject the toolbar's paths,
-  this callback must return ``False`` when ``django.conf.settings.DEBUG`` is ``False``.
+  this callback must return ``False`` when ``django.conf.settings.DEBUG`` is
+  ``False``.
 
   For versions < 1.8, the callback should also return ``False`` for AJAX
   requests. Since version 1.8, AJAX requests are checked in the middleware, not


### PR DESCRIPTION
#### Description

Clarified configuration documentation about ``SHOW_TOOLBAR_CALLBACK``needing to respect ``django.conf.settings.DEBUG`` to match ``debug_toolbar_urls``.

References #2371

#### Checklist:

- [ ] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.

#### AI/LLM Usage
- [ ] This PR includes code generated with the help of an AI/LLM
