### PR TITLE
Handle non-JSON mapping keys in toolbar storage

### DIFF
--- a/debug_toolbar/store.py
+++ b/debug_toolbar/store.py
@@ -27,7 +27,7 @@ def serialize(data: Any) -> str:
     # If this starts throwing an exceptions, consider
     # Subclassing DjangoJSONEncoder and using force_str to
     # make it JSON serializable.
-    return json.dumps(data, cls=DebugToolbarJSONEncoder)
+    return json.dumps(data, cls=DebugToolbarJSONEncoder, skipkeys=True)
 
 
 def deserialize(data: str) -> Any:

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -5,6 +5,8 @@ Pending
 -------
 
 * Prevent check from failing when ``ROOT_URLCONF`` is not defined.
+* Prevent toolbar storage from failing when serialized panel data contains
+  mapping keys that are not JSON-compatible.
 * Prevent debounce race conditions in the history panel for rapid
   fetch requests.
 * Added a note to the prerequisites section of the installation docs

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,12 +2,14 @@ import os
 import re
 import time
 import unittest
+import warnings
 from unittest.mock import patch
 
 import html5lib
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from django.core import signing
 from django.core.cache import cache
+from django.core.cache.backends.base import CacheKeyWarning
 from django.db import connection
 from django.http import HttpResponse
 from django.template.loader import get_template
@@ -208,6 +210,23 @@ class DebugToolbarTestCase(BaseTestCase):
         self.assertEqual(
             len(response.toolbar.get_panel_by_id(CachePanel.panel_id).calls), 1
         )
+
+    def test_cache_panel_store_skips_non_json_keys(self):
+        cache.clear()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", CacheKeyWarning)
+            response = self.client.get("/cache_with_non_json_key/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            len(response.toolbar.get_panel_by_id(CachePanel.panel_id).calls), 1
+        )
+
+        request_id = list(get_store().request_ids())[-1]
+        toolbar = DebugToolbar.fetch(request_id, CachePanel.panel_id)
+        stats = toolbar.get_panel_by_id(CachePanel.panel_id).get_stats()
+        self.assertEqual(stats["calls"][0]["name"], "set_many")
+        self.assertEqual(stats["calls"][0]["args"], [{"foo": "bar"}])
 
     def test_cache_disable_instrumentation(self):
         """

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -24,6 +24,12 @@ class SerializationTestCase(TestCase):
             '{"hello": {"foo": "bar"}}',
         )
 
+    def test_serialize_unexpected(self):
+        self.assertEqual(
+            store.serialize({"hello": {str: "this-is-a-string", "foo": "bar"}}),
+            '{"hello": {"foo": "bar"}}',
+        )
+
     def test_deserialize(self):
         self.assertEqual(
             store.deserialize('{"hello": {"foo": "bar"}}'),

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -25,6 +25,7 @@ urlpatterns = [
     path("async_execute_sql_concurrently/", views.async_execute_sql_concurrently),
     path("cached_view/", views.cached_view),
     path("cached_low_level_view/", views.cached_low_level_view),
+    path("cache_with_non_json_key/", views.cache_with_non_json_key_view),
     path("json_view/", views.json_view),
     path("redirect/", views.redirect_view),
     path("ajax/", views.ajax_view),

--- a/tests/views.py
+++ b/tests/views.py
@@ -106,6 +106,11 @@ def cached_low_level_view(request):
     return render(request, "base.html")
 
 
+def cache_with_non_json_key_view(request):
+    cache.set_many({str: "this-is-a-string", "foo": "bar"})
+    return render(request, "base.html")
+
+
 def json_view(request):
     return JsonResponse({"foo": "bar"})
 


### PR DESCRIPTION
#### Description

Fixes #2189.

Toolbar storage now passes `skipkeys=True` to JSON serialization so panel data containing non-JSON-compatible mapping keys is stored without raising a server error. Valid JSON-compatible keys in the same data remain serialized. This follows the maintainer suggestion on the issue and adds coverage in `SerializationTestCase.test_serialize_unexpected`.

#### Checklist:

- [x] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.

#### AI/LLM Usage
- [x] This PR includes code generated with the help of an AI/LLM

AI/LLM details: OpenAI GPT-5 assisted with the patch and validation.

#### Tests

- `UV_CACHE_DIR=/Users/deepakkudi23/ai-resume-contrib-100/django-debug-toolbar/.uv-cache UV_PROJECT_ENVIRONMENT=/Users/deepakkudi23/ai-resume-contrib-100/django-debug-toolbar/.venv uv run --group dev make test TEST_ARGS=tests.test_store.SerializationTestCase`
- `UV_CACHE_DIR=/Users/deepakkudi23/ai-resume-contrib-100/django-debug-toolbar/.uv-cache UV_PROJECT_ENVIRONMENT=/Users/deepakkudi23/ai-resume-contrib-100/django-debug-toolbar/.venv uv run --group dev make test TEST_ARGS=tests.test_store`
- `UV_CACHE_DIR=/Users/deepakkudi23/ai-resume-contrib-100/django-debug-toolbar/.uv-cache UV_PROJECT_ENVIRONMENT=/Users/deepakkudi23/ai-resume-contrib-100/django-debug-toolbar/.venv uv run --group dev make test`
- `UV_CACHE_DIR=/Users/deepakkudi23/ai-resume-contrib-100/django-debug-toolbar/.uv-cache UV_PROJECT_ENVIRONMENT=/Users/deepakkudi23/ai-resume-contrib-100/django-debug-toolbar/.venv-ruff uv run --with ruff ruff check debug_toolbar/store.py tests/test_store.py`
- `UV_CACHE_DIR=/Users/deepakkudi23/ai-resume-contrib-100/django-debug-toolbar/.uv-cache UV_PROJECT_ENVIRONMENT=/Users/deepakkudi23/ai-resume-contrib-100/django-debug-toolbar/.venv-ruff uv run --with ruff ruff format --check debug_toolbar/store.py tests/test_store.py`
- `UV_CACHE_DIR=/Users/deepakkudi23/ai-resume-contrib-100/django-debug-toolbar/.uv-cache UV_PROJECT_ENVIRONMENT=/Users/deepakkudi23/ai-resume-contrib-100/django-debug-toolbar/.venv uv run --group dev black --check debug_toolbar/store.py tests/test_store.py`
- `git diff --check`