### PR TITLE
Fixed cookie expires calculation

### DIFF
--- a/debug_toolbar/static/debug_toolbar/js/toolbar.js
+++ b/debug_toolbar/static/debug_toolbar/js/toolbar.js
@@ -364,7 +364,7 @@ const djdt = {
             if (typeof options.expires === "number") {
                 const days = options.expires;
                 const expires = new Date();
-                expires.setDate(expires.setDate() + days);
+                expires.setDate(expires.getDate() + days);
                 options.expires = expires;
             }
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -28,7 +28,7 @@ Pending
 * Clarified configuration documentation about ``SHOW_TOOLBAR_CALLBACK``
   needing to respect ``django.conf.settings.DEBUG`` to match
   ``debug_toolbar_urls``.
-* Fixed cookie ``expires`` calculation in ``djdt.cookie.set``. 
+* Fixed cookie ``expires`` calculation in ``djdt.cookie.set``.
 
 6.3.0 (2026-04-01)
 ------------------

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -28,7 +28,7 @@ Pending
 * Clarified configuration documentation about ``SHOW_TOOLBAR_CALLBACK``
   needing to respect ``django.conf.settings.DEBUG`` to match
   ``debug_toolbar_urls``.
-* fix cookie expiry calculation
+* Fixed cookie ``expires`` calculation in ``djdt.cookie.set``. 
 
 6.3.0 (2026-04-01)
 ------------------

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -28,6 +28,7 @@ Pending
 * Clarified configuration documentation about ``SHOW_TOOLBAR_CALLBACK``
   needing to respect ``django.conf.settings.DEBUG`` to match
   ``debug_toolbar_urls``.
+* fix cookie expiry calculation
 
 6.3.0 (2026-04-01)
 ------------------


### PR DESCRIPTION
#### Description
expiries.setDate() was returning NaN, causing all cookies to be set without an expiry date and falling back to session-scoped cookies. So all the user settings will get erase when the restart the browser


The first 3 cookies was set before the fix, all have `session` as expiry 
<img width="699" height="150" alt="image" src="https://github.com/user-attachments/assets/0225bf2c-131b-4f85-9553-e4e885ec1bf8" />

Last 2 two is after the fix, which have correct expiry date

#### Checklist:

- [ ] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.

