### PR TITLE
Change the SQL panel to show the select and explain buttons for all queries

### DIFF
--- a/debug_toolbar/panels/sql/forms.py
+++ b/debug_toolbar/panels/sql/forms.py
@@ -6,7 +6,7 @@ from django.db import connections
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
-from debug_toolbar.panels.sql.utils import is_select_query, reformat_sql
+from debug_toolbar.panels.sql.utils import reformat_sql
 from debug_toolbar.toolbar import DebugToolbar
 
 
@@ -20,14 +20,6 @@ class SQLSelectForm(forms.Form):
 
     request_id = forms.CharField()
     djdt_query_id = forms.CharField()
-
-    def clean_raw_sql(self):
-        value = self.cleaned_data["raw_sql"]
-
-        if not is_select_query(value):
-            raise ValidationError("Only 'select' queries are allowed.")
-
-        return value
 
     def clean_params(self):
         value = self.cleaned_data["params"]

--- a/debug_toolbar/panels/sql/panel.py
+++ b/debug_toolbar/panels/sql/panel.py
@@ -16,7 +16,6 @@ from debug_toolbar.panels.sql.forms import SQLSelectForm
 from debug_toolbar.panels.sql.tracking import wrap_cursor
 from debug_toolbar.panels.sql.utils import (
     contrasting_color_generator,
-    is_select_query,
     reformat_sql,
 )
 from debug_toolbar.utils import render_stacktrace
@@ -271,7 +270,6 @@ class SQLPanel(Panel):
                         query["vendor"], query["trans_status"]
                     )
                 query["is_slow"] = query["duration"] > sql_warning_threshold
-                query["is_select"] = is_select_query(query["raw_sql"])
 
                 query["rgb_color"] = self._databases[alias]["rgb_color"]
                 try:

--- a/debug_toolbar/panels/sql/utils.py
+++ b/debug_toolbar/panels/sql/utils.py
@@ -88,11 +88,6 @@ class EscapedStringSerializer:
         return "".join(escaped_value(token) for token in stmt.flatten())
 
 
-def is_select_query(sql):
-    # UNION queries can start with "(".
-    return sql.lower().lstrip(" (").startswith("select")
-
-
 def reformat_sql(sql, *, with_toggle=False):
     formatted = parse_sql(sql)
     if not with_toggle:

--- a/debug_toolbar/templates/debug_toolbar/panels/sql.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/sql.html
@@ -75,16 +75,14 @@
           </td>
           <td class="djdt-actions">
             {% if query.params %}
-              {% if query.is_select %}
-                <form method="post">
-                  {{ query.form.as_div }}
-                  <button formaction="{% url 'djdt:sql_select' %}" class="remoteCall">Sel</button>
-                  <button formaction="{% url 'djdt:sql_explain' %}" class="remoteCall">Expl</button>
-                  {% if query.vendor == 'mysql' %}
-                    <button formaction="{% url 'djdt:sql_profile' %}" class="remoteCall">Prof</button>
-                  {% endif %}
-                </form>
-              {% endif %}
+              <form method="post">
+                {{ query.form.as_div }}
+                <button formaction="{% url 'djdt:sql_select' %}" class="remoteCall">Sel</button>
+                <button formaction="{% url 'djdt:sql_explain' %}" class="remoteCall">Expl</button>
+                {% if query.vendor == 'mysql' %}
+                  <button formaction="{% url 'djdt:sql_profile' %}" class="remoteCall">Prof</button>
+                {% endif %}
+              </form>
             {% endif %}
           </td>
         </tr>

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -33,6 +33,8 @@ Pending
 * Fixed cookie ``expires`` calculation in ``djdt.cookie.set``.
 * Account for the new ``CULL_PROBABILITY`` in Django 6.2 in tests.
 * Support Django 6.2's handling of booleans for non-PostgreSQL databases.
+* Changed the SQL panel to show the "Select" and "Explain" action buttons for
+  all queries, not just ``SELECT`` statements.
 
 6.3.0 (2026-04-01)
 ------------------

--- a/tests/panels/test_sql.py
+++ b/tests/panels/test_sql.py
@@ -875,8 +875,7 @@ class SQLPanelTestCase(BaseTestCase):
         list(User.objects.filter(id__lt=20).union(User.objects.filter(id__gt=10)))
         response = self.panel.process_request(self.request)
         self.panel.generate_stats(self.request, response)
-        query = self.panel._queries[0]
-        self.assertIn("params", query)
+        self.assertIn("Expl", self.panel.content)
 
     @override_settings(DEBUG_TOOLBAR_CONFIG={"PRETTIFY_SQL": True})
     def test_sql_parse_error_graceful_degradation(self):

--- a/tests/panels/test_sql.py
+++ b/tests/panels/test_sql.py
@@ -876,7 +876,7 @@ class SQLPanelTestCase(BaseTestCase):
         response = self.panel.process_request(self.request)
         self.panel.generate_stats(self.request, response)
         query = self.panel._queries[0]
-        self.assertTrue(query["is_select"])
+        self.assertIn("params", query)
 
     @override_settings(DEBUG_TOOLBAR_CONFIG={"PRETTIFY_SQL": True})
     def test_sql_parse_error_graceful_degradation(self):


### PR DESCRIPTION
#### Description

Previously, the buttons were only shown for SELECT queries. Since we do not accept
SQL from the client we can securely re-run DML queries too.

Fixes #2305 

#### Checklist:

- [x] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.

#### AI/LLM Usage
- [x] This PR includes code generated with the help of an AI/LLM
