### PR TITLE
fix some small issues in docs/installation.rst

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -71,7 +71,7 @@ Second, ensure that your ``TEMPLATES`` setting contains a
     ]
 
 Third, the Debug Toolbar requires an up to date browser and targets [Baseline
-Widely Available](https://web.dev/series/baseline-widely-available) to delivery
+Widely Available](https://web.dev/series/baseline-widely-available) to deliver
 modern debug tools. Should you need to test in an older browser, simply disable
 the toolbar for those sessions.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -71,7 +71,7 @@ Second, ensure that your ``TEMPLATES`` setting contains a
     ]
 
 Third, the Debug Toolbar requires an up to date browser and targets `Baseline
-Widely Available <https://web.dev/series/baseline-widely-available>`_ to deliver
+Widely Available <https://web.dev/baseline/>`_ to deliver
 modern debug tools. Should you need to test in an older browser, simply disable
 the toolbar for those sessions.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -70,8 +70,8 @@ Second, ensure that your ``TEMPLATES`` setting contains a
         }
     ]
 
-Third, the Debug Toolbar requires an up to date browser and targets [Baseline
-Widely Available](https://web.dev/series/baseline-widely-available) to deliver
+Third, the Debug Toolbar requires an up to date browser and targets `Baseline
+Widely Available <https://web.dev/series/baseline-widely-available>`_ to deliver
 modern debug tools. Should you need to test in an older browser, simply disable
 the toolbar for those sessions.
 


### PR DESCRIPTION
#### Description

there's some small issues in docs/installation.rst
- dead link
- improper linking (markdown instead of reST)
- noun "delivery" when apparently a verb is called for

Fixes #2408

#### Checklist:

- [ ] I have added the relevant tests for this change.
- [ ] I have added an item to the Pending section of ``docs/changes.rst``.

#### AI/LLM Usage
- [ ] This PR includes code generated with the help of an AI/LLM
