### PR TITLE
Improve cache hit/miss reporting for `cache.get()`

### DIFF
--- a/debug_toolbar/panels/cache.py
+++ b/debug_toolbar/panels/cache.py
@@ -65,6 +65,7 @@ class CachePanel(Panel):
     is_async = True
 
     _context_locals = Local()
+    _missing_key = object()
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -116,7 +117,12 @@ class CachePanel(Panel):
         template_info,
         backend,
     ):
-        if name == "get" or name == "get_or_set":
+        if name == "get":
+            if return_value is self._missing_key:
+                self.misses += 1
+            else:
+                self.hits += 1
+        elif name == "get_or_set":
             if return_value is None:
                 self.misses += 1
             else:
@@ -149,9 +155,22 @@ class CachePanel(Panel):
         # monkey-patched cache methods to skip recording additional calls made during
         # the course of this call, and then reset it back afterward.
         cache._djdt_panel = None
+        user_default = None
         try:
             start_time = perf_counter()
-            value = original_method(*args, **kwargs)
+            if name == "get":
+                user_default = kwargs.get("default", args[1] if len(args) > 1 else None)
+                # Replace the caller's default with an internal sentinel so a cache miss
+                # can be distinguished from a cached value equal to the supplied default.
+                if "default" in kwargs:
+                    call_args = args
+                    call_kwargs = {**kwargs, "default": self._missing_key}
+                else:
+                    call_args = (args[0], self._missing_key, *args[2:])
+                    call_kwargs = kwargs
+                value = original_method(*call_args, **call_kwargs)
+            else:
+                value = original_method(*args, **kwargs)
             t = perf_counter() - start_time
         finally:
             cache._djdt_panel = self
@@ -166,6 +185,10 @@ class CachePanel(Panel):
             template_info=get_template_info(),
             backend=f"{alias} ({type(cache).__name__})",
         )
+        # Preserve the original cache.get() behavior by returning the caller's
+        # default instead of the internal sentinel on a cache miss.
+        if name == "get" and value is self._missing_key:
+            return user_default
         return value
 
     # Implement the Panel API

--- a/debug_toolbar/panels/cache.py
+++ b/debug_toolbar/panels/cache.py
@@ -149,7 +149,7 @@ class CachePanel(Panel):
 
     def _record_call(self, cache, alias, name, original_method, args, kwargs):
         # Some cache backends implement certain cache methods in terms of other cache
-        # methods (e.g. get_or_set() in terms of get() and add()).  In order to only
+        # methods (e.g. get_or_set() in terms of get() and add()). In order to only
         # record the calls made directly by the user code, set the cache's _djdt_panel
         # attribute to None before invoking the original method, which will cause the
         # monkey-patched cache methods to skip recording additional calls made during
@@ -162,12 +162,15 @@ class CachePanel(Panel):
                 user_default = kwargs.get("default", args[1] if len(args) > 1 else None)
                 # Replace the caller's default with an internal sentinel so a cache miss
                 # can be distinguished from a cached value equal to the supplied default.
+                call_args = args
+                call_kwargs = kwargs
                 if "default" in kwargs:
-                    call_args = args
                     call_kwargs = {**kwargs, "default": self._missing_key}
-                else:
+                elif args:
                     call_args = (args[0], self._missing_key, *args[2:])
-                    call_kwargs = kwargs
+                else:
+                    # Key was supplied as a keyword argument.
+                    call_kwargs = {**kwargs, "default": self._missing_key}
                 value = original_method(*call_args, **call_kwargs)
             else:
                 value = original_method(*args, **kwargs)

--- a/debug_toolbar/panels/cache.py
+++ b/debug_toolbar/panels/cache.py
@@ -65,7 +65,6 @@ class CachePanel(Panel):
     is_async = True
 
     _context_locals = Local()
-    _missing_key = object()
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -118,7 +117,8 @@ class CachePanel(Panel):
         backend,
     ):
         if name == "get":
-            if return_value is self._missing_key:
+            default = kwargs.get("default", args[1] if len(args) > 1 else None)
+            if return_value == default:
                 self.misses += 1
             else:
                 self.hits += 1
@@ -155,25 +155,9 @@ class CachePanel(Panel):
         # monkey-patched cache methods to skip recording additional calls made during
         # the course of this call, and then reset it back afterward.
         cache._djdt_panel = None
-        user_default = None
         try:
             start_time = perf_counter()
-            if name == "get":
-                user_default = kwargs.get("default", args[1] if len(args) > 1 else None)
-                # Replace the caller's default with an internal sentinel so a cache miss
-                # can be distinguished from a cached value equal to the supplied default.
-                call_args = args
-                call_kwargs = kwargs
-                if "default" in kwargs:
-                    call_kwargs = {**kwargs, "default": self._missing_key}
-                elif args:
-                    call_args = (args[0], self._missing_key, *args[2:])
-                else:
-                    # Key was supplied as a keyword argument.
-                    call_kwargs = {**kwargs, "default": self._missing_key}
-                value = original_method(*call_args, **call_kwargs)
-            else:
-                value = original_method(*args, **kwargs)
+            value = original_method(*args, **kwargs)
             t = perf_counter() - start_time
         finally:
             cache._djdt_panel = self
@@ -188,10 +172,6 @@ class CachePanel(Panel):
             template_info=get_template_info(),
             backend=f"{alias} ({type(cache).__name__})",
         )
-        # Preserve the original cache.get() behavior by returning the caller's
-        # default instead of the internal sentinel on a cache miss.
-        if name == "get" and value is self._missing_key:
-            return user_default
         return value
 
     # Implement the Panel API

--- a/debug_toolbar/static/debug_toolbar/css/toolbar.css
+++ b/debug_toolbar/static/debug_toolbar/css/toolbar.css
@@ -348,7 +348,14 @@
     height: 50px;
 }
 
-#djDebug .djDebugPanelTitle code {
+#djDebug .djdt-cache-note {
+    margin: 1em 0;
+    padding: 8px 10px;
+    border: 1px solid var(--djdt-table-border-color);
+    background-color: var(--djdt-panel-content-table-strip-background-color);
+}
+#djDebug .djDebugPanelTitle code,
+#djDebug .djdt-cache-note code {
     display: inline;
     font-size: inherit;
 }

--- a/debug_toolbar/templates/debug_toolbar/panels/cache.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/cache.html
@@ -18,6 +18,11 @@
     </tr>
   </tbody>
 </table>
+<p class="djdt-cache-note">
+    Cache hit/miss statistics for <code>cache.get()</code> calls may not always be accurate.
+    See <a href="https://github.com/django-commons/django-debug-toolbar/discussions/2441">the discussion</a>
+    for details and to share feedback about improving cache hit/miss tracking.
+</p>
 <h4>{% translate "Commands" %}</h4>
 <table>
   <thead>

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -7,6 +7,10 @@ Pending
 * Fixed the Django version check in the SQL panel test suite for Django's
   boolean parameter handling.
 
+* Fixed incorrect cache hit/miss reporting in the Cache panel for
+  ``cache.get()`` when a default value is supplied or the cached value is
+  ``None``.
+
 7.0.0 (2026-06-17)
 ------------------
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -22,6 +22,10 @@ Pending
   before the panel script has loaded, which navigated away from the page.
 * Added support for Django 6.1.
 
+* Fixed incorrect cache hit/miss reporting in the Cache panel for
+  ``cache.get()`` when a default value is supplied or the cached value is
+  ``None``.
+
 7.0.0 (2026-06-17)
 ------------------
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -21,10 +21,9 @@ Pending
 * Stopped the history panel buttons from submitting their form when clicked
   before the panel script has loaded, which navigated away from the page.
 * Added support for Django 6.1.
-
-* Fixed incorrect cache hit/miss reporting in the Cache panel for
-  ``cache.get()`` when a default value is supplied or the cached value is
-  ``None``.
+* Improved cache hit/miss reporting in the Cache panel for ``cache.get()``
+  calls with a supplied default value, while documenting the remaining
+  ambiguity when a cached value equals the supplied default.
 
 7.0.0 (2026-06-17)
 ------------------

--- a/docs/panels.rst
+++ b/docs/panels.rst
@@ -101,6 +101,12 @@ Cache
 
 Cache queries. Is incompatible with Django's per-site caching.
 
+Cache hit/miss statistics for ``cache.get()`` calls may not always be
+accurate. See the `discussion`_ for details and to share feedback about
+improving cache hit/miss tracking.
+
+.. _discussion: https://github.com/django-commons/django-debug-toolbar/discussions/2441
+
 Signals
 ~~~~~~~
 

--- a/tests/panels/test_cache.py
+++ b/tests/panels/test_cache.py
@@ -76,6 +76,28 @@ class CachePanelTestCase(BaseTestCase):
         self.assertEqual(self.panel.hits, 1)
         self.assertEqual(self.panel.misses, 0)
 
+    def test_get_with_keyword_default_is_cache_miss(self):
+        cache.cache.clear()
+
+        self.assertEqual(cache.cache.get("foo", default="default"), "default")
+        self.assertEqual(self.panel.hits, 0)
+        self.assertEqual(self.panel.misses, 1)
+
+    def test_get_with_keyword_key_and_default_is_cache_miss(self):
+        cache.cache.clear()
+
+        self.assertEqual(cache.cache.get(key="foo", default="default"), "default")
+        self.assertEqual(self.panel.hits, 0)
+        self.assertEqual(self.panel.misses, 1)
+
+    def test_get_with_keyword_key_and_version(self):
+        cache.cache.clear()
+
+        cache.cache.set("foo", "bar", version=1)
+        self.assertEqual(cache.cache.get(key="foo", version=1), "bar")
+        self.assertEqual(self.panel.hits, 1)
+        self.assertEqual(self.panel.misses, 0)
+
     def test_get_or_set_value(self):
         cache.cache.get_or_set("baz", "val")
         self.assertEqual(cache.cache.get("baz"), "val")

--- a/tests/panels/test_cache.py
+++ b/tests/panels/test_cache.py
@@ -45,6 +45,37 @@ class CachePanelTestCase(BaseTestCase):
         self.assertEqual(self.panel.hits, 4)
         self.assertEqual(self.panel.misses, 2)
 
+    def test_cached_none_counts_as_hit(self):
+        cache.cache.clear()
+
+        cache.cache.set("foo", None)
+        self.assertIsNone(cache.cache.get("foo"))
+        self.assertEqual(self.panel.hits, 1)
+        self.assertEqual(self.panel.misses, 0)
+
+    def test_missing_key_with_default_counts_as_miss(self):
+        cache.cache.clear()
+
+        self.assertIsNone(cache.cache.get("foo", None))
+        self.assertEqual(self.panel.hits, 0)
+        self.assertEqual(self.panel.misses, 1)
+
+    def test_missing_key_returns_supplied_default(self):
+        cache.cache.clear()
+
+        self.assertEqual(cache.cache.get("foo", "bar"), "bar")
+        self.assertEqual(self.panel.hits, 0)
+        self.assertEqual(self.panel.misses, 1)
+
+    def test_cached_value_equal_to_default_counts_as_hit(self):
+        cache.cache.clear()
+
+        cache.cache.set("foo", "bar")
+        self.assertEqual(cache.cache.get("foo", "bar"), "bar")
+
+        self.assertEqual(self.panel.hits, 1)
+        self.assertEqual(self.panel.misses, 0)
+
     def test_get_or_set_value(self):
         cache.cache.get_or_set("baz", "val")
         self.assertEqual(cache.cache.get("baz"), "val")

--- a/tests/panels/test_cache.py
+++ b/tests/panels/test_cache.py
@@ -45,57 +45,41 @@ class CachePanelTestCase(BaseTestCase):
         self.assertEqual(self.panel.hits, 4)
         self.assertEqual(self.panel.misses, 2)
 
-    def test_cached_none_with_default_none_is_ambiguous(self):
+    def test_get_default_counts_as_miss(self):
+        """
+        Using get that fetches a cached value that's the same as the default
+        results in a miss despite it being a hit.
+        """
         cache.cache.clear()
 
+        # cached None with default None is ambiguous
         cache.cache.set("foo", None)
         self.assertIsNone(cache.cache.get("foo"))
+        self.assertIsNone(cache.cache.get("foo"))
+        self.assertEqual(self.panel.misses, 2)
         self.assertEqual(self.panel.hits, 0)
-        self.assertEqual(self.panel.misses, 1)
 
-    def test_cached_value_equal_to_default_is_ambiguous(self):
+        # cached value equal to default is ambiguous
+        cache.cache.set("bar", "baz")
+        self.assertEqual(cache.cache.get("bar", "baz"), "baz")
+        self.assertEqual(cache.cache.get("bar", "baz"), "baz")
+        self.assertEqual(self.panel.misses, 4)
+        self.assertEqual(self.panel.hits, 0)
+
+    def test_get_with_args(self):
+        """
+        Test get to calculate the default in a variety of ways.
+        """
         cache.cache.clear()
-
-        cache.cache.set("foo", "bar")
+        self.assertIsNone(cache.cache.get("foo"))
+        self.assertEqual(self.panel.misses, 1)
         self.assertEqual(cache.cache.get("foo", "bar"), "bar")
+        self.assertEqual(self.panel.misses, 2)
+        self.assertEqual(cache.cache.get("foo", default="bar"), "bar")
+        self.assertEqual(self.panel.misses, 3)
+        self.assertEqual(cache.cache.get(key="foo", default="bar"), "bar")
+        self.assertEqual(self.panel.misses, 4)
         self.assertEqual(self.panel.hits, 0)
-        self.assertEqual(self.panel.misses, 1)
-
-    def test_missing_key_with_default_counts_as_miss(self):
-        cache.cache.clear()
-
-        self.assertIsNone(cache.cache.get("foo", None))
-        self.assertEqual(self.panel.hits, 0)
-        self.assertEqual(self.panel.misses, 1)
-
-    def test_missing_key_returns_supplied_default(self):
-        cache.cache.clear()
-
-        self.assertEqual(cache.cache.get("foo", "bar"), "bar")
-        self.assertEqual(self.panel.hits, 0)
-        self.assertEqual(self.panel.misses, 1)
-
-    def test_get_with_keyword_default_is_cache_miss(self):
-        cache.cache.clear()
-
-        self.assertEqual(cache.cache.get("foo", default="default"), "default")
-        self.assertEqual(self.panel.hits, 0)
-        self.assertEqual(self.panel.misses, 1)
-
-    def test_get_with_keyword_key_and_default_is_cache_miss(self):
-        cache.cache.clear()
-
-        self.assertEqual(cache.cache.get(key="foo", default="default"), "default")
-        self.assertEqual(self.panel.hits, 0)
-        self.assertEqual(self.panel.misses, 1)
-
-    def test_get_with_keyword_key_and_version(self):
-        cache.cache.clear()
-
-        cache.cache.set("foo", "bar", version=1)
-        self.assertEqual(cache.cache.get(key="foo", version=1), "bar")
-        self.assertEqual(self.panel.hits, 1)
-        self.assertEqual(self.panel.misses, 0)
 
     def test_get_or_set_value(self):
         cache.cache.get_or_set("baz", "val")
@@ -167,11 +151,15 @@ class CachePanelTestCase(BaseTestCase):
         )
 
     def test_get_or_set_none_counts_as_miss(self):
+        """
+        Using get_or_set to set a None value is counted as a miss even
+        though it was a hit on the second try.
+        """
         cache.cache.clear()
-
         self.assertIsNone(cache.cache.get_or_set("foo", None))
+        self.assertIsNone(cache.cache.get_or_set("foo", None))
+        self.assertEqual(self.panel.misses, 2)
         self.assertEqual(self.panel.hits, 0)
-        self.assertEqual(self.panel.misses, 1)
 
     def test_insert_content(self):
         """

--- a/tests/panels/test_cache.py
+++ b/tests/panels/test_cache.py
@@ -167,6 +167,13 @@ class CachePanelTestCase(BaseTestCase):
             },
         )
 
+    def test_get_or_set_none_counts_as_miss(self):
+        cache.cache.clear()
+
+        self.assertIsNone(cache.cache.get_or_set("foo", None))
+        self.assertEqual(self.panel.hits, 0)
+        self.assertEqual(self.panel.misses, 1)
+
     def test_insert_content(self):
         """
         Test that the panel only inserts content after generate_stats and

--- a/tests/panels/test_cache.py
+++ b/tests/panels/test_cache.py
@@ -45,13 +45,21 @@ class CachePanelTestCase(BaseTestCase):
         self.assertEqual(self.panel.hits, 4)
         self.assertEqual(self.panel.misses, 2)
 
-    def test_cached_none_counts_as_hit(self):
+    def test_cached_none_with_default_none_is_ambiguous(self):
         cache.cache.clear()
 
         cache.cache.set("foo", None)
         self.assertIsNone(cache.cache.get("foo"))
-        self.assertEqual(self.panel.hits, 1)
-        self.assertEqual(self.panel.misses, 0)
+        self.assertEqual(self.panel.hits, 0)
+        self.assertEqual(self.panel.misses, 1)
+
+    def test_cached_value_equal_to_default_is_ambiguous(self):
+        cache.cache.clear()
+
+        cache.cache.set("foo", "bar")
+        self.assertEqual(cache.cache.get("foo", "bar"), "bar")
+        self.assertEqual(self.panel.hits, 0)
+        self.assertEqual(self.panel.misses, 1)
 
     def test_missing_key_with_default_counts_as_miss(self):
         cache.cache.clear()
@@ -66,15 +74,6 @@ class CachePanelTestCase(BaseTestCase):
         self.assertEqual(cache.cache.get("foo", "bar"), "bar")
         self.assertEqual(self.panel.hits, 0)
         self.assertEqual(self.panel.misses, 1)
-
-    def test_cached_value_equal_to_default_counts_as_hit(self):
-        cache.cache.clear()
-
-        cache.cache.set("foo", "bar")
-        self.assertEqual(cache.cache.get("foo", "bar"), "bar")
-
-        self.assertEqual(self.panel.hits, 1)
-        self.assertEqual(self.panel.misses, 0)
 
     def test_get_with_keyword_default_is_cache_miss(self):
         cache.cache.clear()


### PR DESCRIPTION
#### Description

This change fixes incorrect cache hit/miss reporting in the Cache panel for `cache.get()`.

Previously, the Cache panel determined whether a `cache.get()` call was a hit or a miss solely based on whether the returned value was `None`. This resulted in two incorrect scenarios:

A missing key with a supplied default (for example, `cache.get("missing", "default")`) was reported as a cache hit, even though the value was not retrieved from the cache.
A cached value of `None` was reported as a cache miss, even though the key existed in the cache.

The Cache panel now correctly distinguishes between a missing cache key and a cached value equal to the caller's supplied default while preserving the existing `cache.get()` behavior.

Fixes #2417 

#### Checklist:

- [x] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.

#### AI/LLM Usage
- [x] This PR includes code generated with the help of an AI/LLM
