### PR TITLE
Fix show_toolbar_with_docker on runtimes with unrelated host address

### DIFF
--- a/debug_toolbar/middleware.py
+++ b/debug_toolbar/middleware.py
@@ -66,6 +66,10 @@ def show_toolbar_with_docker(request: HttpRequest) -> bool:
     # to an address that is unrelated to the container network, so the check
     # above cannot derive the host address from it.
     try:
+        # Make a reasonable guess at the gateway from the container's own
+        # interface. This assumes the process is running inside a container.
+        # If this were used outside a container this would grant access to
+        # anything that appears to come from the network's gateway (router).
         container_ips = socket.gethostbyname_ex(socket.gethostname())[2]
         gateways = {ip.rsplit(".", 1)[0] + ".1" for ip in container_ips}
         if request.META.get("REMOTE_ADDR") in gateways:

--- a/debug_toolbar/middleware.py
+++ b/debug_toolbar/middleware.py
@@ -48,11 +48,9 @@ def show_toolbar_with_docker(request: HttpRequest) -> bool:
     if not settings.DEBUG:
         return False
 
-    # Test: settings
     if request.META.get("REMOTE_ADDR") in settings.INTERNAL_IPS:
         return True
 
-    # Test: Docker
     try:
         # This is a hack for docker installations. It attempts to look
         # up the IP address of the docker host.
@@ -68,18 +66,19 @@ def show_toolbar_with_docker(request: HttpRequest) -> bool:
         # It's fine if the lookup errored since they may not be using docker
         pass
 
-    # Test: Docker, falling back to the gateway of the container's own network.
     # Some Docker runtimes (for example OrbStack) resolve host.docker.internal
     # to an address that is unrelated to the container network, so the check
     # above cannot derive the host address from it.
     try:
         container_ips = socket.gethostbyname_ex(socket.gethostname())[2]
+        gateways = {ip.rsplit(".", 1)[0] + ".1" for ip in container_ips}
+        if request.META.get("REMOTE_ADDR") in gateways:
+            return True
     except socket.gaierror:
         # It's fine if the lookup errored since they may not be using docker
-        return False
-
-    gateways = {ip.rsplit(".", 1)[0] + ".1" for ip in container_ips}
-    return request.META.get("REMOTE_ADDR") in gateways
+        pass
+    
+    return False
 
 
 @cache

--- a/debug_toolbar/middleware.py
+++ b/debug_toolbar/middleware.py
@@ -77,7 +77,7 @@ def show_toolbar_with_docker(request: HttpRequest) -> bool:
     except socket.gaierror:
         # It's fine if the lookup errored since they may not be using docker
         pass
-    
+
     return False
 
 

--- a/debug_toolbar/middleware.py
+++ b/debug_toolbar/middleware.py
@@ -68,8 +68,18 @@ def show_toolbar_with_docker(request: HttpRequest) -> bool:
         # It's fine if the lookup errored since they may not be using docker
         pass
 
-    # No test passed
-    return False
+    # Test: Docker, falling back to the gateway of the container's own network.
+    # Some Docker runtimes (for example OrbStack) resolve host.docker.internal
+    # to an address that is unrelated to the container network, so the check
+    # above cannot derive the host address from it.
+    try:
+        container_ips = socket.gethostbyname_ex(socket.gethostname())[2]
+    except socket.gaierror:
+        # It's fine if the lookup errored since they may not be using docker
+        return False
+
+    gateways = {ip.rsplit(".", 1)[0] + ".1" for ip in container_ips}
+    return request.META.get("REMOTE_ADDR") in gateways
 
 
 @cache

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -6,6 +6,8 @@ Pending
 
 * Fixed the Django version check in the SQL panel test suite for Django's
   boolean parameter handling.
+* Fixed ``show_toolbar_with_docker`` on Docker runtimes such as OrbStack that
+  resolve ``host.docker.internal`` to an address outside the container network.
 
 7.0.0 (2026-06-17)
 ------------------

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -163,6 +163,13 @@ option.
     Docker gateway IP and treat it as an allowable internal IP so that the
     toolbar is shown to you.
 
+    When the Docker host lookup fails, the ``show_toolbar_with_docker``
+    callback guesses the host's address from the container's own network. If
+    run outside a container that guess can resolve to another machine on your
+    network, granting it access to the toolbar's data. The
+    ``show_toolbar_with_docker`` callback should only be used inside a
+    container.
+
 7. Disable the toolbar when running tests (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -62,6 +62,7 @@ refactoring
 reinitializing
 resizing
 runserver
+runtimes
 spellchecking
 sphinxcontrib
 spooler

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -89,6 +89,21 @@ class DebugToolbarTestCase(BaseTestCase):
             self.assertTrue(show_toolbar_with_docker(self.request))
         mocked_gethostbyname.assert_called_once_with("host.docker.internal")
 
+    @patch("socket.gethostbyname", return_value="0.250.250.254")
+    @patch("socket.gethostname", return_value="container")
+    @patch(
+        "socket.gethostbyname_ex",
+        return_value=("container", [], ["192.168.215.7"]),
+    )
+    def test_show_toolbar_docker_unrelated_host_address(self, *mocks):
+        """Runtimes such as OrbStack resolve host.docker.internal to an
+        address outside of the container network, so the host address has to
+        be derived from the container's own address instead."""
+        self.request.META["REMOTE_ADDR"] = "192.168.215.1"
+        with self.settings(INTERNAL_IPS=[]):
+            self.assertFalse(show_toolbar(self.request))
+            self.assertTrue(show_toolbar_with_docker(self.request))
+
     def test_not_iterating_over_INTERNAL_IPS(self):
         """Verify that the middleware does not iterate over INTERNAL_IPS in some way.
 


### PR DESCRIPTION
#### Description

`show_toolbar_with_docker` derives the Docker host address by resolving
`host.docker.internal` and replacing the last segment with `.1`. On OrbStack
that name resolves to `0.250.250.254`, which is outside the container network,
so the derived address never matches `REMOTE_ADDR` and the toolbar stays
hidden. When that probe does not match, the host address is now derived from
the container's own addresses instead.

Fixes #2419

#### Checklist:

- [x] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.

#### AI/LLM Usage
- [ ] This PR includes code generated with the help of an AI/LLM
