### PR TITLE
Make show_toolbar_with_docker work when host.docker.internal is not the gateway

### DIFF
--- a/debug_toolbar/middleware.py
+++ b/debug_toolbar/middleware.py
@@ -68,6 +68,20 @@ def show_toolbar_with_docker(request: HttpRequest) -> bool:
         # It's fine if the lookup errored since they may not be using docker
         pass
 
+    # Test: Docker, without relying on host.docker.internal
+    # Some runtimes (e.g. OrbStack) either do not provide host.docker.internal
+    # or resolve it to an address that is not the gateway. Fall back to
+    # guessing the gateway from the container's own addresses.
+    try:
+        container_ips = socket.gethostbyname_ex(socket.gethostname())[2]
+    except socket.gaierror:
+        # It's fine if the lookup errored since they may not be using docker
+        pass
+    else:
+        gateways = {ip.rsplit(".", 1)[0] + ".1" for ip in container_ips}
+        if request.META.get("REMOTE_ADDR") in gateways:
+            return True
+
     # No test passed
     return False
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -6,6 +6,9 @@ Pending
 
 * Fixed the Django version check in the SQL panel test suite for Django's
   boolean parameter handling.
+* ``show_toolbar_with_docker`` now also guesses the Docker host from the
+  container's own addresses, so it works on runtimes such as OrbStack where
+  ``host.docker.internal`` does not resolve to the gateway.
 
 7.0.0 (2026-06-17)
 ------------------

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -89,6 +89,23 @@ class DebugToolbarTestCase(BaseTestCase):
             self.assertTrue(show_toolbar_with_docker(self.request))
         mocked_gethostbyname.assert_called_once_with("host.docker.internal")
 
+    @patch(
+        "socket.gethostbyname_ex",
+        return_value=("container", [], ["127.0.0.42"]),
+    )
+    @patch("socket.gethostbyname", return_value="0.250.250.254")
+    def test_show_toolbar_docker_gateway_fallback(
+        self, mocked_gethostbyname, mocked_gethostbyname_ex
+    ):
+        """host.docker.internal may not resolve to the host, e.g. on OrbStack.
+
+        Fall back to guessing the gateway from the container's own addresses.
+        """
+        with self.settings(INTERNAL_IPS=[]):
+            self.assertFalse(show_toolbar(self.request))
+            self.assertTrue(show_toolbar_with_docker(self.request))
+        mocked_gethostbyname.assert_called_once_with("host.docker.internal")
+
     def test_not_iterating_over_INTERNAL_IPS(self):
         """Verify that the middleware does not iterate over INTERNAL_IPS in some way.
 


### PR DESCRIPTION
#### Description

On [OrbStack](https://orbstack.dev/), `host.docker.internal` resolves to `0.250.250.254`, which is unrelated to the container network, so the address computed by `show_toolbar_with_docker` never matches `REMOTE_ADDR` and the toolbar is not shown.

This keeps the existing `host.docker.internal` check first and adds a fallback that derives the candidate gateways from the container's own addresses, as suggested in the issue.

Fixes #2419

#### Checklist:

- [x] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.

#### AI/LLM Usage
- [ ] This PR includes code generated with the help of an AI/LLM
