### PR TITLE
Fix integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,13 +133,13 @@ jobs:
             - python-version: '3.13'
               database: psycopg3
               env:
-                DJANGO_SELENIUM_TESTS=true
+                DJANGO_SELENIUM_TESTS: "true"
             - python-version: '3.14'
               database: postgis3
             - python-version: '3.14'
               database: psycopg3
               env:
-                DJANGO_SELENIUM_TESTS=true
+                DJANGO_SELENIUM_TESTS: "true"
 
     services:
       postgres:

--- a/debug_toolbar/static/debug_toolbar/js/utils.js
+++ b/debug_toolbar/static/debug_toolbar/js/utils.js
@@ -102,7 +102,7 @@ export async function ajax(url, init) {
         }
         throw new Error(`${response.status}: ${response.statusText}`);
     } catch (error) {
-        const win = document.getElementById("djDebugWindow");
+        const win = getDebugElement().querySelector("#djDebugWindow");
         win.innerHTML = `<div class="djDebugPanelTitle"><h3>${error.message}</h3><button type="button" class="djDebugClose">»</button></div>`;
         $$.show(win);
         throw error;

--- a/debug_toolbar/templates/debug_toolbar/panels/history.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/history.html
@@ -1,7 +1,7 @@
 {% load i18n static %}
 <form method="get" action="{% url 'djdt:history_refresh' %}">
     {{ refresh_form.as_div }}
-    <button class="refreshHistory">Refresh</button>
+    <button type="button" class="refreshHistory">Refresh</button>
 </form>
 <table class="djdt-max-height-100">
     <thead>

--- a/debug_toolbar/templates/debug_toolbar/panels/history_tr.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/history_tr.html
@@ -44,7 +44,7 @@
     <td class="djdt-actions">
         <form method="get" action="{% url 'djdt:history_sidebar' %}">
             {{ history_context.form.as_div }}
-            <button data-request-id="{{ request_id }}" class="switchHistory">Switch</button>
+            <button type="button" data-request-id="{{ request_id }}" class="switchHistory">Switch</button>
         </form>
     </td>
 </tr>

--- a/debug_toolbar/templates/debug_toolbar/panels/sql.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/sql.html
@@ -74,7 +74,7 @@
             {{ query.duration|floatformat:"2" }}ms
           </td>
           <td class="djdt-actions">
-            {% if query.params %}
+            {% if query.params is not None %}
               <form method="post">
                 {{ query.form.as_div }}
                 <button formaction="{% url 'djdt:sql_select' %}" class="remoteCall">Sel</button>

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -13,6 +13,8 @@ Pending
   parameters.
 * Fixed the error shown when panel content fails to load, which could not
   find the toolbar window inside the shadow root.
+* Stopped the history panel buttons from submitting their form when clicked
+  before the panel script has loaded, which navigated away from the page.
 
 7.0.0 (2026-06-17)
 ------------------

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -11,6 +11,8 @@ Pending
   boolean parameter handling.
 * Restored the select and explain buttons for queries that run without
   parameters.
+* Fixed the error shown when panel content fails to load, which could not
+  find the toolbar window inside the shadow root.
 
 7.0.0 (2026-06-17)
 ------------------

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -9,6 +9,8 @@ Pending
   older versions of Django, the panel explains that upgrading is required.
 * Fixed the Django version check in the SQL panel test suite for Django's
   boolean parameter handling.
+* Restored the select and explain buttons for queries that run without
+  parameters.
 
 7.0.0 (2026-06-17)
 ------------------

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -711,6 +711,27 @@ class DebugToolbarLiveTestCase(StaticLiveServerTestCase):
         options.set_preference("ui.prefersReducedMotion", 0)
         cls.selenium = webdriver.Firefox(options=options)
 
+        # The toolbar renders into an open shadow root, which find_element
+        # cannot see into, so fall back to searching within it.
+        find_element = cls.selenium.find_element
+        selectors = {
+            By.ID: "#{}",
+            By.CLASS_NAME: ".{}",
+            By.TAG_NAME: "{}",
+            By.CSS_SELECTOR: "{}",
+        }
+
+        def find_including_toolbar(by, value):
+            try:
+                return find_element(by, value)
+            except NoSuchElementException:
+                shadow_root = find_element(By.ID, "djDebugRoot").shadow_root
+                return shadow_root.find_element(
+                    By.CSS_SELECTOR, selectors[by].format(value)
+                )
+
+        cls.selenium.find_element = find_including_toolbar
+
     @classmethod
     def tearDownClass(cls):
         cls.selenium.quit()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -759,8 +759,8 @@ class DebugToolbarLiveTestCase(StaticLiveServerTestCase):
         table = self.wait.until(
             lambda selenium: version_panel.find_element(By.TAG_NAME, "table")
         )
-        self.assertIn("Name", table.text)
-        self.assertIn("Version", table.text)
+        self.assertIn("Name", table.get_attribute("textContent"))
+        self.assertIn("Version", table.get_attribute("textContent"))
 
     @override_settings(
         DEBUG_TOOLBAR_CONFIG={
@@ -906,8 +906,8 @@ class DebugToolbarLiveTestCase(StaticLiveServerTestCase):
         table = self.wait.until(
             lambda selenium: sql_panel.find_element(By.TAG_NAME, "table")
         )
-        self.assertIn("Query", table.text)
-        self.assertIn("Action", table.text)
+        self.assertIn("Query", table.get_attribute("textContent"))
+        self.assertIn("Action", table.get_attribute("textContent"))
 
     @override_settings(DEBUG_TOOLBAR_CONFIG={"TOOLBAR_LANGUAGE": "pt-br"})
     def test_toolbar_language_will_render_to_locale_when_set(self):
@@ -924,8 +924,8 @@ class DebugToolbarLiveTestCase(StaticLiveServerTestCase):
         table = self.wait.until(
             lambda selenium: sql_panel.find_element(By.TAG_NAME, "table")
         )
-        self.assertIn("Query", table.text)
-        self.assertIn("Linha", table.text)
+        self.assertIn("Query", table.get_attribute("textContent"))
+        self.assertIn("Linha", table.get_attribute("textContent"))
 
     @override_settings(DEBUG_TOOLBAR_CONFIG={"TOOLBAR_LANGUAGE": "en-us"})
     @override_settings(LANGUAGE_CODE="de")
@@ -943,8 +943,8 @@ class DebugToolbarLiveTestCase(StaticLiveServerTestCase):
         table = self.wait.until(
             lambda selenium: sql_panel.find_element(By.TAG_NAME, "table")
         )
-        self.assertIn("Query", table.text)
-        self.assertIn("Action", table.text)
+        self.assertIn("Query", table.get_attribute("textContent"))
+        self.assertIn("Action", table.get_attribute("textContent"))
 
     def test_ajax_dont_refresh(self):
         self.get("/ajax/")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -788,16 +788,30 @@ class DebugToolbarLiveTestCase(StaticLiveServerTestCase):
         self.get("/regular_jinja/basic")
         # Make a new request so the history panel has more than one option.
         self.get("/execute_sql/")
-        template_panel = self.selenium.find_element(By.ID, HistoryPanel.panel_id)
         # Record the current side panel of buttons for later comparison.
+        previous_request_id = self.selenium.find_element(
+            By.ID, "djDebug"
+        ).get_attribute("data-request-id")
         previous_button_panel = self.selenium.find_element(
             By.ID, "djDebugPanelList"
         ).text
 
         # Click to show the history panel
         self.selenium.find_element(By.CLASS_NAME, HistoryPanel.panel_id).click()
+
         # Click to switch back to the jinja page view snapshot
-        list(template_panel.find_elements(By.CSS_SELECTOR, "button"))[-1].click()
+        def switch_to_oldest_snapshot(selenium):
+            buttons = selenium.find_element(By.ID, HistoryPanel.panel_id).find_elements(
+                By.CSS_SELECTOR, ".switchHistory"
+            )
+            if buttons:
+                buttons[-1].click()
+            return (
+                selenium.find_element(By.ID, "djDebug").get_attribute("data-request-id")
+                != previous_request_id
+            )
+
+        self.wait.until(switch_to_oldest_snapshot)
 
         current_button_panel = self.selenium.find_element(
             By.ID, "djDebugPanelList"


### PR DESCRIPTION
#### Description

While working on selenium tests for https://github.com/django-commons/django-debug-toolbar/pull/2433, I noticed the ones on `main` were already failing. Here's a bundle of small patches to get integration tests back up & running.

Patches:
* **[Search the toolbar's shadow root in the Selenium tests](https://github.com/django-commons/django-debug-toolbar/commit/5bfc6426fe5edae316da2242f96306670df384d4)** - The tests look elements up on the document, which cannot see into the open shadow root the toolbar has rendered into since https://github.com/django-commons/django-debug-toolbar/pull/2266, so every lookup raised `NoSuchElementException`. Fall back to searching the shadow root when the document search finds nothing, which leaves the existing call sites unchanged.
* [Assert on table textContent in the Selenium tests](https://github.com/django-commons/django-debug-toolbar/commit/345888ae038762bb2c1112a55b2c842b308966d2) - The panel stylesheet uppercases table headers and `WebElement.text` returns rendered text, so the assertions no longer matched the source strings. Read textContent instead, which is untransformed.
* [Show the SQL select and explain buttons for queries without parameters](https://github.com/django-commons/django-debug-toolbar/commit/bc5df6c649f2496c696369398b03c21c3bb40893) - The buttons are wrapped in a check on query.params, which held a JSON string until that changed to the decoded value. An empty list of parameters then read as empty and the buttons stopped rendering, so a query with no parameters lost its actions.

  Compare against None instead, which is what the panel records when the parameters cannot be serialized. This restores the behaviour the check had while the value was a string.
* [Find the toolbar window inside the shadow root when a panel errors](https://github.com/django-commons/django-debug-toolbar/commit/c42aac42c951c23d5fa1a22dcddbb846b3affc19) - The failure branch of ajax() reached for the window with document.getElementById, which cannot see into the shadow root the toolbar renders into, so the lookup returned null and the handler threw instead of reporting the error. Every other reference already goes through the toolbar element.
* [Actually run the Selenium tests in CI](https://github.com/django-commons/django-debug-toolbar/commit/ce74113d75f5873d8e9a1702e930b70997c12fcd) - The matrix entries carry env: followed by a plain scalar, so it parses
as the string `"DJANGO_SELENIUM_TESTS=true"` rather than a mapping, and `matrix.env.DJANGO_SELENIUM_TESTS` resolves to nothing. The suite has been skipping since the job was added.

  Make it a mapping. The runner image already provides Firefox and geckodriver, and the tests run headless when CI is set, so no extra setup is needed.
* [Stop the history panel buttons from submitting their forms](https://github.com/django-commons/django-debug-toolbar/pull/2434/commits/6cc4e492786585a1342ecad759635c0309ddff83) - Both buttons sit in a form and carry no type, so they default to submit. They only avoid navigating because history.js calls preventDefault, and that script loads with the panel, so a click landing first sends the browser to the raw JSON of the sidebar or refresh view. The toolbar is then gone from the page, which is what the switch test hit on CI.

  The forms are read by ajaxForm rather than submitted, so nothing needs the submit behaviour. Clicking early is now a no-op instead, so the test retries the click until the switch takes effect.

#### Checklist:

- [x] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.

#### AI/LLM Usage
- [x] This PR includes code generated with the help of an AI/LLM
