### PR TITLE
Serialize the TaskResult class for Tasks panel.

### DIFF
--- a/debug_toolbar/panels/tasks.py
+++ b/debug_toolbar/panels/tasks.py
@@ -52,10 +52,26 @@ class TasksPanel(Panel):
             task_enqueued.disconnect(self._record_task)
 
     def generate_stats(self, request, response):
-        # Pass TaskResult objects directly to the template
+        # TaskResult and Task aren't JSON-serializable which the toolbar's
+        # storage mechanism requires
+        tasks = [
+            {
+                "task": {
+                    "module_path": task_result.task.module_path,
+                    "queue_name": task_result.task.queue_name,
+                    "priority": task_result.task.priority,
+                    "run_after": task_result.task.run_after,
+                },
+                "backend": task_result.backend,
+                "status": task_result.status,
+                "args": task_result.args,
+                "kwargs": task_result.kwargs,
+            }
+            for task_result in self.tasks
+        ]
         self.record_stats(
             {
                 "tasks_available": VERSION >= (6, 0),
-                "tasks": self.tasks,
+                "tasks": tasks,
             }
         )

--- a/debug_toolbar/templates/debug_toolbar/panels/tasks.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/tasks.html
@@ -24,13 +24,7 @@
           <td>{{ task.status }}</td>
           <td><code>{{ task.args|pprint }}</code></td>
           <td>
-            <code>
-              {% if task.kwargs %}
-                {{ task.kwargs|pprint }}
-              {% else %}
-                —
-              {% endif %}
-            </code>
+            <code>{% if task.kwargs %}{{ task.kwargs|pprint }}{% else %}—{% endif %}</code>
           </td>
         </tr>
       {% endfor %}

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -3,6 +3,9 @@ Change log
 
 Pending
 
+* Serialize ``TaskResult`` in the Tasks panel to accommodate the storage
+  mechanism.
+
 7.1.0 (2026-08-10)
 ------------------
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -5,6 +5,7 @@ Pending
 
 * Serialize ``TaskResult`` in the Tasks panel to accommodate the storage
   mechanism.
+* Removed whitespace on Task panel's ``kwargs`` column.
 
 7.1.0 (2026-08-10)
 ------------------

--- a/tests/panels/test_tasks.py
+++ b/tests/panels/test_tasks.py
@@ -11,13 +11,6 @@ def sample_task(x, y=1):
     return x + y
 
 
-class UnserializableObject:
-    """A value that json.dumps() can't natively handle."""
-
-    def __repr__(self):
-        return "<UnserializableObject>"
-
-
 class TasksPanelTestCase(BaseTestCase):
     panel_id = TasksPanel.panel_id
 
@@ -67,15 +60,12 @@ class TasksPanelTestCase(BaseTestCase):
         are accessed to render the content, we should validate the properties
         explicitly rather than solely relying on test_records_queued_task
         confirming the shape.
-
-        This round-trips through the store (as happens for real via the
-        render_panel view) rather than reading the panel's in-memory stats,
-        since that's the step that previously stringified the whole
-        TaskResult and broke rendering (issue #2443).
         """
         sample_task.enqueue(2, y=3)
 
         self.panel.generate_stats(self.request, None)
+        # This round-trips through the store rather than reading the
+        # panel's in-memory stats.
         self.reload_stats()
         content = self.panel.content
 

--- a/tests/panels/test_tasks.py
+++ b/tests/panels/test_tasks.py
@@ -11,6 +11,13 @@ def sample_task(x, y=1):
     return x + y
 
 
+class UnserializableObject:
+    """A value that json.dumps() can't natively handle."""
+
+    def __repr__(self):
+        return "<UnserializableObject>"
+
+
 class TasksPanelTestCase(BaseTestCase):
     panel_id = TasksPanel.panel_id
 
@@ -43,15 +50,14 @@ class TasksPanelTestCase(BaseTestCase):
         self.assertEqual(stats["tasks_available"], True)
         self.assertEqual(len(stats["tasks"]), 1)
         task_result = stats["tasks"][0]
-        self.assertEqual(task_result.task.module_path, f"{__name__}.sample_task")
-        self.assertEqual(task_result.task.queue_name, "default")
-        self.assertEqual(task_result.task.priority, 0)
-        self.assertEqual(task_result.backend, "default")
-        self.assertEqual(task_result.task.run_after, None)
-        self.assertEqual(task_result.task.takes_context, False)
-        self.assertEqual(task_result.args, [2])
-        self.assertEqual(task_result.kwargs, {"y": 3})
-        self.assertEqual(task_result.status, "SUCCESSFUL")
+        self.assertEqual(task_result["task"]["module_path"], f"{__name__}.sample_task")
+        self.assertEqual(task_result["task"]["queue_name"], "default")
+        self.assertEqual(task_result["task"]["priority"], 0)
+        self.assertEqual(task_result["backend"], "default")
+        self.assertEqual(task_result["task"]["run_after"], None)
+        self.assertEqual(task_result["args"], [2])
+        self.assertEqual(task_result["kwargs"], {"y": 3})
+        self.assertEqual(task_result["status"], "SUCCESSFUL")
 
     @unittest.skipUnless(django_has_tasks_support, "Requires Django 6.0+")
     def test_records_queued_task_rendered_in_template(self):
@@ -61,10 +67,16 @@ class TasksPanelTestCase(BaseTestCase):
         are accessed to render the content, we should validate the properties
         explicitly rather than solely relying on test_records_queued_task
         confirming the shape.
+
+        This round-trips through the store (as happens for real via the
+        render_panel view) rather than reading the panel's in-memory stats,
+        since that's the step that previously stringified the whole
+        TaskResult and broke rendering (issue #2443).
         """
         sample_task.enqueue(2, y=3)
 
         self.panel.generate_stats(self.request, None)
+        self.reload_stats()
         content = self.panel.content
 
         # task.task.module_path


### PR DESCRIPTION
#### Description

This serializes the Tasks panel's content so it can be stored and fetched. It also resolves the issue of extra whitespace on the `kwargs` column of the tasks panel.

Fixes #2443

#### Checklist:

- [x] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.

#### AI/LLM Usage
- [x] This PR includes code generated with the help of an AI/LLM
