### PR TITLE
Initial Oracle Database support to the SQL Explain panel

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -261,6 +261,77 @@ jobs:
         path: .coverage.sqlite.${{ matrix.python-version }}*
         include-hidden-files: true
 
+  oracle:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 5
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+
+    services:
+      oracle:
+        image: gvenzl/oracle-free:23.26.2-slim-faststart
+        env:
+          ORACLE_PASSWORD: oracle_secret_pass
+        ports:
+          - 1521:1521
+        options: >-
+          --health-cmd "healthcheck.sh"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+          --health-start-period 60s
+          --health-start-interval 5s
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      with:
+        persist-credentials: false
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+      with:
+        python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
+
+    - name: Get pip cache dir
+      id: pip-cache
+      run: |
+        echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+
+    - name: Cache Pip Dependencies
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+      with:
+        path: ${{ steps.pip-cache.outputs.dir }}
+        key:
+          ${{ matrix.python-version }}-v1-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/tox.ini') }}
+        restore-keys: |
+          ${{ matrix.python-version }}-v1-
+        lookup-only: true
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install --upgrade tox tox-gh-actions
+
+    - name: Test with tox
+      run: tox
+      env:
+        DB_BACKEND: oracle
+        DB_NAME: localhost:1521/FREEPDB1
+        DB_USER: system
+        DB_PASSWORD: oracle_secret_pass
+        DB_HOST: ""
+        DB_PORT: ""
+        COVERAGE_FILE: ".coverage.oracle.${{ matrix.python-version }}"
+
+    - name: Store coverage file
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+      with:
+        name: coverage-oracle-${{ matrix.python-version }}
+        path: .coverage.oracle.${{ matrix.python-version }}*
+        include-hidden-files: true
+
   lint:
     runs-on: ubuntu-latest
     strategy:
@@ -306,6 +377,7 @@ jobs:
       - mysql
       - postgres
       - sqlite
+      - oracle
     permissions:
       pull-requests: write
       contents: write

--- a/debug_toolbar/panels/sql/forms.py
+++ b/debug_toolbar/panels/sql/forms.py
@@ -79,6 +79,13 @@ class SQLSelectForm(forms.Form):
                 cursor.execute(f"EXPLAIN QUERY PLAN {sql}", params)
             elif vendor == "postgresql":
                 cursor.execute(f"EXPLAIN ANALYZE {sql}", params)
+            elif vendor == "oracle":
+                from debug_toolbar.panels.sql.oracle_helper import (
+                    OracleExplainPlanHelper,
+                )
+
+                helper = OracleExplainPlanHelper(cursor)
+                return helper.execute(sql, params)
             else:
                 cursor.execute(f"EXPLAIN {sql}", params)
             headers = [d[0] for d in cursor.description]

--- a/debug_toolbar/panels/sql/oracle_helper.py
+++ b/debug_toolbar/panels/sql/oracle_helper.py
@@ -1,0 +1,394 @@
+import logging
+import uuid
+
+from django.db import DatabaseError
+
+logger = logging.getLogger(__name__)
+
+
+class OracleExplainPlanHelper:
+    """
+    A helper class to run, format, and audit Oracle SQL EXPLAIN PLANs.
+
+    Architecture & Lifecycle:
+        Unlike unified single-command engines (like PostgreSQL's "EXPLAIN ANALYZE"),
+        Oracle requires an orchestrated multi-step workflow:
+        1. Generation: Executes "EXPLAIN PLAN" to estimate cost and record execution
+           path nodes under a unique STATEMENT_ID in the session's PLAN_TABLE.
+        2. Formatting: Queries "DBMS_XPLAN.DISPLAY" to extract and format those nodes
+           from the PLAN_TABLE into structured, human-readable ASCII text.
+        3. Auditing: Parses the plan nodes to identify all accessed tables and indexes,
+           fetching their performance, status, and size metadata from the Oracle
+           dictionary catalog views (ALL_TABLES & ALL_INDEXES).
+        4. ASCII Rendering: Appends the catalog metrics formatted as aligned ASCII tables.
+        5. Cleanup: Deletes the temporary nodes created in PLAN_TABLE to prevent session
+           pollution and table growth.
+        6. QBR Suppression: Conditionally filters out the Query Block Registry section.
+
+    Security Mandate:
+        Because the Oracle "EXPLAIN PLAN" syntax requires the literal query text,
+        this class performs direct string interpolation on the `sql` argument.
+        IT IS MANDATORY that any caller ensures the `sql` argument is safe and
+        pre-validated against SQL injection before executing. Within the toolbar's
+        context, this is secure as SQL strings are fetched solely from the
+        cryptographically signed server-side cache.
+
+    Database Version Adaptation:
+        - Oracle < 21: The database outputs the Query Block Registry (QBR) as raw
+          nested XML. This XML can cause infinite recursion and memory exhaustion on
+          unprepared markdown parsers (such as certain LLM CLIs). The helper
+          automatically identifies and suppresses this section if `suppress_qbr_block`
+          is active and the connection version is legacy to 21.
+        - Oracle 21c/23c+: The database natively formats the QBR as clean, structured,
+          hierarchical plain text. The helper preserves and displays this text safely.
+
+    Class Attributes:
+        display_format (str): The formatting arguments passed to DBMS_XPLAN.DISPLAY.
+                              Defaults to "ADVANCED +ADAPTIVE".
+        chunk_size (int): The maximum number of table/index names processed in a single
+                          IN clause when fetching catalog statistics. Defaults to 50.
+        suppress_qbr_block (bool): Whether to suppress the Query Block Registry for
+                                   Oracle < 21 connections. Defaults to True.
+        include_catalog_audit (bool): Whether to query and append the metadata tables
+                                      for tables and indexes. Defaults to True.
+    """
+
+    display_format = "ADVANCED +ADAPTIVE"
+    chunk_size = 50
+    suppress_qbr_block = True
+    include_catalog_audit = True
+
+    def __init__(self, cursor):
+        self.cursor = cursor
+
+    def execute(self, sql, params):
+        """
+        Orchestrates the Oracle explain workflow:
+        1. Run EXPLAIN PLAN using a unique statement ID.
+        2. Query DBMS_XPLAN.DISPLAY for the detailed execution plan.
+        3. Attempt to fetch database catalog statistics for involved schemas.
+        4. Render schema health audit reports as aligned ASCII tables.
+        5. Clean up temporary rows from the PLAN_TABLE.
+        6. Suppress the dangerous "Query Block Registry" block.
+        """
+        stmt_id = f"dt_{uuid.uuid4().hex[:25]}"
+
+        try:
+            # 1. Fetch raw execution plan lines from DBMS_XPLAN
+            result = self._fetch_raw_plan(sql, params, stmt_id)
+
+            # 2. Extract involved tables/indexes for schema health audit
+            if self.include_catalog_audit:
+                try:
+                    # Graceful fallback: skip optional audit if catalog
+                    # views are inaccessible.
+                    table_keys = self._get_involved_tables(stmt_id)
+                    if table_keys:
+                        table_stats, index_stats = self._fetch_catalog_statistics(
+                            table_keys
+                        )
+                        audit_lines = self._render_stats_as_ascii(
+                            table_stats, index_stats
+                        )
+                        for line in audit_lines:
+                            result.append((line,))
+                except DatabaseError as e:
+                    # Sanitize the error to prevent leaking sensitive schema
+                    # names or data. Extract the generic exception class name
+                    # to assist in debugging without PII.
+                    error_type = type(e).__name__
+                    logger.warning(
+                        "Oracle catalog audit skipped due to a database "
+                        "exception [%s]. This usually indicates restricted "
+                        "user permissions on dictionary views.",
+                        error_type,
+                    )
+
+            # 3. Suppress "Query Block Registry" to
+            # prevent client OOM on some LLMs
+            # on Oracle < 21
+            if self.suppress_qbr_block and self._oracle_version < (21,):
+                result = self._suppress_qbr(result)
+            return result, ["PLAN_TABLE_OUTPUT"]
+
+        finally:
+            self._cleanup_plan_table(stmt_id)
+
+    def _fetch_raw_plan(self, sql, params, stmt_id):
+        """
+        Executes the statement explain and retrieves plan lines.
+
+        Note on Two-Query Flow: Unlike PostgreSQL's unified single-command
+        "EXPLAIN ANALYZE", Oracle separates execution plan generation from
+        plan formatting. The first query executes "EXPLAIN PLAN" to generate
+        and write the raw plan metadata into the session's PLAN_TABLE.
+        The second query then calls "dbms_xplan.display" as a table function
+        to fetch, format, and return those rows as structured ASCII text.
+
+        Note on SQL Safety: Refer to the Security Mandate in the class docstring.
+        Values inside `sql` remain safely bound via `params`.
+        """
+        self.cursor.execute(
+            f"EXPLAIN PLAN SET STATEMENT_ID = '{stmt_id}' FOR {sql}", params
+        )
+        self.cursor.execute(
+            "SELECT plan_table_output FROM table(dbms_xplan.display("
+            f"'PLAN_TABLE', %s, '{self.display_format}'))",
+            [stmt_id],
+        )
+        return self.cursor.fetchall()
+
+    def _get_involved_tables(self, stmt_id):
+        """
+        Interrogates PLAN_TABLE and reverse maps indexes
+        to identify all involved tables.
+        """
+        # Get active connection username to resolve any NULL owners
+        current_user = None
+        raw_cursor = getattr(self.cursor, "cursor", None)
+        if raw_cursor and hasattr(raw_cursor, "connection"):
+            current_user = getattr(raw_cursor.connection, "username", None)
+        if current_user:
+            current_user = current_user.upper()
+
+        # Fetch tables from PLAN_TABLE
+        self.cursor.execute(
+            (
+                "SELECT DISTINCT object_owner, object_name "
+                "FROM PLAN_TABLE "
+                "WHERE statement_id = %s "
+                "AND object_type = 'TABLE' "
+                "AND object_name IS NOT NULL"
+            ),
+            [stmt_id],
+        )
+        tbl_rows = self.cursor.fetchall()
+        table_keys = {
+            (r[0].upper() if r[0] else current_user, r[1]) for r in tbl_rows if r[1]
+        }
+
+        # Fetch indexes from PLAN_TABLE
+        self.cursor.execute(
+            (
+                "SELECT DISTINCT object_owner, object_name "
+                "FROM PLAN_TABLE "
+                "WHERE statement_id = %s "
+                "AND object_type = 'INDEX' "
+                "AND object_name IS NOT NULL"
+            ),
+            [stmt_id],
+        )
+        idx_rows = self.cursor.fetchall()
+        idx_keys = [
+            (r[0].upper() if r[0] else current_user, r[1]) for r in idx_rows if r[1]
+        ]
+
+        # Reverse map index ownership to locate parent tables in all_indexes
+        if idx_keys:
+            for i in range(0, len(idx_keys), self.chunk_size):
+                chunk = idx_keys[i : i + self.chunk_size]
+                conditions = " OR ".join(
+                    ["(owner = %s AND index_name = %s)"] * len(chunk)
+                )
+                params = []
+                for owner, name in chunk:
+                    params.extend([owner, name])
+
+                self.cursor.execute(
+                    (
+                        "SELECT DISTINCT table_owner, table_name "
+                        "FROM all_indexes "
+                        f"WHERE {conditions}"
+                    ),
+                    params,
+                )
+                mapped_tbl_rows = self.cursor.fetchall()
+                for r in mapped_tbl_rows:
+                    if r[1]:
+                        table_keys.add((r[0], r[1]))
+
+        return table_keys
+
+    def _fetch_catalog_statistics(self, table_keys):
+        """
+        Fetches bulk performance statistics and health flags
+        from standard dictionary views.
+        """
+        table_stats = []
+        index_stats = []
+        table_keys_list = list(table_keys)
+
+        for i in range(0, len(table_keys_list), self.chunk_size):
+            chunk = table_keys_list[i : i + self.chunk_size]
+
+            table_conditions = []
+            table_params = []
+            for owner, name in chunk:
+                table_conditions.append("(owner = %s AND table_name = %s)")
+                table_params.extend([owner, name])
+
+            table_where_clause = " OR ".join(table_conditions)
+
+            # Retrieve table storage metrics
+            self.cursor.execute(
+                (
+                    "SELECT owner, table_name, num_rows, blocks, avg_row_len, "
+                    "TO_CHAR(last_analyzed, 'YYYY-MM-DD HH24:MI:SS') as "
+                    "last_analyzed "
+                    "FROM all_tables "
+                    f"WHERE {table_where_clause}"
+                ),
+                table_params,
+            )
+            table_stats.extend(self.cursor.fetchall())
+
+            # Retrieve index performance and integrity statuses
+            self.cursor.execute(
+                (
+                    "SELECT owner, index_name, table_name, uniqueness, status, "
+                    "TO_CHAR(last_analyzed, 'YYYY-MM-DD HH24:MI:SS') as "
+                    "last_analyzed "
+                    "FROM all_indexes "
+                    f"WHERE {table_where_clause} "
+                    "ORDER BY table_name, index_name"
+                ),
+                table_params,
+            )
+            index_stats.extend(self.cursor.fetchall())
+
+        return table_stats, index_stats
+
+    def _render_stats_as_ascii(self, table_stats, index_stats):
+        """
+        Formats the database metadata and catalog rows
+        into visual, aligned ASCII tables.
+        """
+        if not table_stats and not index_stats:
+            return []
+
+        # Determine dynamic column widths to fit all content cleanly
+        t_col_owner = max([len(str(r[0])) for r in table_stats] + [15])
+        t_col_name = max([len(str(r[1])) for r in table_stats] + [30])
+        table_border = (
+            f"+{'-' * (t_col_owner + 2)}+{'-' * (t_col_name + 2)}+"
+            f"{'-' * 12}+{'-' * 12}+{'-' * 13}+{'-' * 21}+"
+        )
+
+        idx_col_owner = max([len(str(r[0])) for r in index_stats] + [15])
+        idx_col_name = max([len(str(r[1])) for r in index_stats] + [30])
+        t_col_idx = max([len(str(r[2])) for r in index_stats] + [25])
+        index_border = (
+            f"+{'-' * (idx_col_owner + 2)}+{'-' * (idx_col_name + 2)}+"
+            f"{'-' * (t_col_idx + 2)}+{'-' * 12}+{'-' * 10}+{'-' * 21}+"
+        )
+
+        audit_lines = [
+            "",
+            "",
+            "Schema Health & Statistics Audit (ALL_TABLES & ALL_INDEXES)",
+            "================================================================",
+            "Table Statistics:",
+            table_border,
+            (
+                f"| {'Owner':<{t_col_owner}} | {'Table Name':<{t_col_name}} | "
+                f"{'Num Rows':<10} | {'Blocks':<10} | {'Avg Row Len':<11} | "
+                f"{'Last Analyzed':<19} |"
+            ),
+            table_border,
+        ]
+
+        for r in table_stats:
+            owner = str(r[0])
+            t_name = str(r[1])
+            num_rows = str(r[2]) if r[2] is not None else "—"
+            blocks = str(r[3]) if r[3] is not None else "—"
+            avg_len = str(r[4]) if r[4] is not None else "—"
+            analyzed = str(r[5]) if r[5] is not None else "—"
+            audit_lines.append(
+                f"| {owner:<{t_col_owner}} | {t_name:<{t_col_name}} | "
+                f"{num_rows:<10} | {blocks:<10} | {avg_len:<11} | "
+                f"{analyzed:<19} |"
+            )
+        audit_lines.append(table_border)
+
+        audit_lines.extend(
+            [
+                "",
+                "Index Statistics & Status:",
+                index_border,
+                (
+                    f"| {'Owner':<{idx_col_owner}} | {'Index Name':<{idx_col_name}} | "
+                    f"{'Table Name':<{t_col_idx}} | {'Uniqueness':<10} | "
+                    f"{'Status':<8} | {'Last Analyzed':<19} |"
+                ),
+                index_border,
+            ]
+        )
+
+        for r in index_stats:
+            owner = str(r[0])
+            idx_name = str(r[1])
+            t_name = str(r[2])
+            uniq = str(r[3])
+            status = str(r[4])
+            analyzed = str(r[5]) if r[5] is not None else "—"
+            audit_lines.append(
+                f"| {owner:<{idx_col_owner}} | {idx_name:<{idx_col_name}} | "
+                f"{t_name:<{t_col_idx}} | {uniq:<10} | {status:<8} | "
+                f"{analyzed:<19} |"
+            )
+        audit_lines.append(index_border)
+
+        return audit_lines
+
+    @property
+    def _oracle_version(self):
+        """Resolves the Oracle database version tuple dynamically."""
+        db = getattr(self.cursor, "db", None)
+        version = getattr(db, "oracle_version", None)
+        if isinstance(version, (tuple, list)):
+            return version
+        return (19,)  # Safe fallback for Oracle < 21 and mock/test environments
+
+    def _suppress_qbr(self, result):
+        """Locates and slices out Query Block Registry lines."""
+        qbr_start = None
+        qbr_end = None
+
+        for i, row in enumerate(result):
+            line = row[0] if row and row[0] is not None else ""
+            if "Query Block Registry:" in line:
+                qbr_start = i
+                break
+
+        if qbr_start is None:
+            return result
+
+        # Find where the QBR block ends.
+        # Any line starting with a non-space character (excluding dashed/equals lines or
+        # empty lines) indicates the end of the QBR block and start of another section.
+        for i in range(qbr_start + 2, len(result)):
+            line = result[i][0] if result[i] and result[i][0] is not None else ""
+            stripped = line.strip()
+            if not stripped:
+                continue
+            if not line.startswith(" ") and not all(c in "-=" for c in stripped):
+                qbr_end = i
+                break
+
+        if qbr_end is not None:
+            return result[:qbr_start] + result[qbr_end:]
+        return result[:qbr_start]
+
+    def _cleanup_plan_table(self, stmt_id):
+        """Deletes any temporary rows created in PLAN_TABLE."""
+        try:
+            self.cursor.execute(
+                "DELETE FROM PLAN_TABLE WHERE statement_id = %s", [stmt_id]
+            )
+        except DatabaseError as e:
+            error_type = type(e).__name__
+            logger.warning(
+                "Failed to clean up PLAN_TABLE [%s]. Session pollution may occur.",
+                error_type,
+            )

--- a/debug_toolbar/panels/sql/tracking.py
+++ b/debug_toolbar/panels/sql/tracking.py
@@ -269,7 +269,8 @@ class NormalCursorMixin(DjDTCursorWrapperMixin):
             # Skip tracking for toolbar models by default.
             # This can be overridden by setting SKIP_TOOLBAR_QUERIES = False
             if not dt_settings.get_config()["SKIP_TOOLBAR_QUERIES"] or not any(
-                table in sql for table in DDT_MODELS
+                table in sql or self.db.ops.quote_name(table) in sql
+                for table in DDT_MODELS
             ):
                 # We keep `sql` to maintain backwards compatibility
                 self.logger.record(**kwargs)

--- a/debug_toolbar/panels/sql/utils.py
+++ b/debug_toolbar/panels/sql/utils.py
@@ -23,7 +23,7 @@ class ElideSelectListsFilter:
                 keyword = value.upper()
                 if allow_elision and keyword == "SELECT":
                     yield from self.elide_until_from(stream)
-                allow_elision = keyword in ["EXCEPT", "INTERSECT", "UNION"]
+                allow_elision = keyword in ["EXCEPT", "INTERSECT", "UNION", "MINUS"]
 
     @staticmethod
     def elide_until_from(stream):

--- a/debug_toolbar/panels/sql/views.py
+++ b/debug_toolbar/panels/sql/views.py
@@ -65,6 +65,7 @@ def sql_explain(request):
             "duration": query["duration"],
             "headers": headers,
             "alias": query["alias"],
+            "vendor": query["vendor"],
         }
         content = render_to_string("debug_toolbar/panels/sql_explain.html", context)
         return JsonResponse({"content": content})

--- a/debug_toolbar/static/debug_toolbar/css/toolbar.css
+++ b/debug_toolbar/static/debug_toolbar/css/toolbar.css
@@ -1367,3 +1367,19 @@ To regenerate:
     background-color: #fff;
     color: #131313;
 }
+
+#djDebug .djdt-scroll-spacer {
+    height: 25vh;
+}
+
+#djDebug .djdt-oracle-preds-content {
+    background-color: var(--djdt-background-color);
+    border: 1px solid var(--djdt-pre-border-color);
+    padding: 10px;
+    color: var(--djdt-pre-text-color);
+    font-family: var(--djdt-font-family-monospace);
+    font-size: 11px;
+    line-height: 1.5;
+    overflow-x: auto;
+    margin-top: 0.8em;
+}

--- a/debug_toolbar/templates/debug_toolbar/panels/sql_explain.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/sql_explain.html
@@ -13,6 +13,13 @@
       <dt>{% translate "Database" %}</dt>
       <dd>{{ alias }}</dd>
     </dl>
+    {% if vendor == 'oracle' %}
+      <dt>ORACLE {% for h in headers %}{{ h|upper }}{% endfor %}:</dt>
+      <dd>
+      <pre class="djdt-oracle-preds-content">{% for row in result %}{{ row.0|escape }}
+{% endfor %}</pre>
+      </dd>
+    {% else %}
     <table>
       <thead>
         <tr>
@@ -31,5 +38,7 @@
         {% endfor %}
       </tbody>
     </table>
+    {% endif %}
+    <div class="djdt-scroll-spacer"></div>
   </div>
 </div>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,58 @@
+# setup databases to running
+# tests in local development
+name: "dtb"
+services:
+  postgresql:
+    image: postgis/postgis:17-3.5
+    container_name: postgresql_test
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_DB=debug_toolbar
+      - POSTGRES_USER=debug_toolbar
+      - POSTGRES_PASSWORD=debug_toolbar
+    volumes:
+      - pg_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U debug_toolbar"]
+      interval: 10s
+      timeout: 10s
+      retries: 10
+
+  mysql:
+    image: mariadb:11.8
+    container_name: mysql_test
+    ports:
+      - "3306:3306"
+    environment:
+      - MARIADB_ROOT_PASSWORD=debug_toolbar
+      - MARIADB_DATABASE=debug_toolbar
+    volumes:
+      - mysql_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD-SHELL", "mariadb-admin ping -pdebug_toolbar"]
+      interval: 10s
+      timeout: 10s
+      retries: 10
+
+  oracle-db:
+    image: gvenzl/oracle-free:23.26.2-slim-faststart
+    container_name: oracle_db_free
+    ports:
+      - "1521:1521"
+    environment:
+      - ORACLE_PASSWORD=oracle_secret_pass
+    volumes:
+      - oracle_data:/opt/oracle/oradata
+    healthcheck:
+      test: ["CMD", "healthcheck.sh"]
+      interval: 10s
+      timeout: 5s
+      retries: 60
+      start_period: 5s
+      start_interval: 5s
+
+volumes:
+  pg_data:
+  mysql_data:
+  oracle_data:

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -3,6 +3,18 @@ Change log
 
 Pending
 
+* Added support for Oracle Database on the SQL explain panel. It uses
+  Oracle's ``EXPLAIN PLAN`` and ``DBMS_XPLAN.DISPLAY`` to show a
+  detailed execution plan.
+* Added a section "Schema Health and Statistics Audit" on the
+  SQL explain panel for Oracle Database. It reports performance
+  metrics and size metadata of involved tables and indexes that
+  was not covered by ``DBMS_XPLAN.DISPLAY``.
+* Added an Oracle Database test job to the GitHub Actions workflow matrix.
+* Added an Oracle Database test job to the tox workflow matrix.
+* Added a local ``docker-compose.yml`` configuration to easily run all
+  supported test databases locally.
+* Configured ``tox`` to output distinct coverage data.
 * Refreshed the toolbar's visual design with self-hosted Alef (panel titles)
   and Geist (body text) fonts, an updated color palette, and per-panel
   navigation icons.

--- a/docs/panels.rst
+++ b/docs/panels.rst
@@ -69,6 +69,68 @@ SQL
 
 SQL queries including time to execute and links to EXPLAIN each query.
 
+On Oracle databases, the Explain feature executes the static ``EXPLAIN PLAN``
+and formats the detailed execution path using `DBMS_XPLAN.DISPLAY`_. Because
+this is a static estimation plan, the actual query is **not** executed,
+making the explain operation safe, instant, and risk-free even on large
+production tables.
+
+It also automatically performs a **Schema Health and Statistics Audit**
+on all tables and indexes involved in the query, providing developers
+with actionable diagnostics on where and what to optimize:
+
+* **Identifying Bottlenecks (Plan Table):** Look for ``TABLE ACCESS FULL``
+  inside the ``Operation`` column for large tables, which indicates missing
+  indexes. In the ``Predicate Information`` section at the bottom, columns
+  under ``access`` indicate efficient index lookups (index seeks), while
+  columns under ``filter`` indicate inefficient row-by-row filtering after
+  retrieval, highlighting the need for composite or better-structured
+  indexes.
+* **Index Health (Index Status):** The index statistics audit table
+  displays the current status of each index. If an index's ``Status`` is
+  ``UNUSABLE`` (common after bulk data loads or partition operations), the
+  Oracle optimizer will silently ignore it and fall back to slow table scans.
+
+  .. caution::
+     **Avoid offline rebuilds in production:** Running ``ALTER INDEX name
+     REBUILD;`` without the ``ONLINE`` keyword will lock the target table
+     exclusively, blocking all incoming application writes. Always reconstruct
+     live indexes in the background. For details, see the official
+     `Oracle ALTER INDEX Reference`_:
+
+     .. code-block:: sql
+
+         ALTER INDEX index_name REBUILD ONLINE;
+
+* **Stale Statistics (Last Analyzed):** The Oracle Cost-Based Optimizer
+  (CBO) relies entirely on up-to-date database statistics to choose the
+  most efficient path. If the ``Last Analyzed`` column in the table or
+  index statistics is empty (``—``) or very old, the optimizer will
+  estimate costs based on outdated data.
+
+  .. caution::
+     **Schedule statistics gathering off-peak:** Running
+     ``DBMS_STATS.GATHER_TABLE_STATS`` on massive tables causes heavy CPU and
+     disk I/O load. Always schedule statistics gathering during low-traffic
+     maintenance windows, and use Oracle's optimal automatic sampling to
+     prevent system performance degradation. For details, see the official
+     `Oracle DBMS_STATS Reference`_:
+
+     .. code-block:: sql
+
+         EXEC DBMS_STATS.GATHER_TABLE_STATS('OWNER', 'TABLE_NAME', estimate_percent => DBMS_STATS.AUTO_SAMPLE_SIZE);
+
+* **Optimizer Path (Query Block Registry):** Displays the logical
+  transformations applied by the optimizer (such as view merging or
+  subquery unnesting). To ensure stability, the complex raw XML format
+  produced in Oracle 19c is suppressed to protect browser and terminal
+  clients from memory overhead, while on Oracle 21c and 23c+ it is
+  rendered in clean, structured hierarchical text.
+
+.. _DBMS_XPLAN.DISPLAY: https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/DBMS_XPLAN.html
+.. _Oracle ALTER INDEX Reference: https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/ALTER-INDEX.html
+.. _Oracle DBMS_STATS Reference: https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/DBMS_STATS.html
+
 Static files
 ~~~~~~~~~~~~
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -85,12 +85,14 @@ stacktrace
 stacktraces
 startup
 staticfiles
+subquery
 theming
 timeline
 tox
 uWSGI
 unhandled
 unhashable
+unnesting
 validator
 wordmark
 wordmarks

--- a/example/settings.py
+++ b/example/settings.py
@@ -103,6 +103,17 @@ if os.environ.get("DB_BACKEND", "").lower() == "mysql":
             "PASSWORD": "debug_toolbar",
         }
     }
+if os.environ.get("DB_BACKEND", "").lower() == "oracle":
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.oracle",
+            "NAME": "localhost:1521/FREEPDB1",
+            "USER": "system",
+            "PASSWORD": "oracle_secret_pass",
+            "HOST": "",
+            "PORT": "",
+        }
+    }
 
 STATICFILES_DIRS = [os.path.join(BASE_DIR, "example", "static")]
 

--- a/tests/panels/test_sql.py
+++ b/tests/panels/test_sql.py
@@ -166,7 +166,10 @@ class SQLPanelTestCase(BaseTestCase):
         # ensure query was logged
         self.assertEqual(len(self.panel._queries), 1)
         query = self.panel._queries[0]
-        self.assertTrue(HistoryEntry._meta.db_table in query["sql"])
+        table = HistoryEntry._meta.db_table
+        self.assertTrue(
+            table in query["sql"] or connection.ops.quote_name(table) in query["sql"]
+        )
 
     @override_settings(
         DEBUG_TOOLBAR_CONFIG={
@@ -187,7 +190,10 @@ class SQLPanelTestCase(BaseTestCase):
         # ensure query was logged
         self.assertEqual(len(self.panel._queries), 1)
         query = self.panel._queries[0]
-        self.assertTrue(HistoryEntry._meta.db_table in query["sql"])
+        table = HistoryEntry._meta.db_table
+        self.assertTrue(
+            table in query["sql"] or connection.ops.quote_name(table) in query["sql"]
+        )
 
     @override_settings(
         DEBUG_TOOLBAR_CONFIG={
@@ -224,6 +230,65 @@ class SQLPanelTestCase(BaseTestCase):
         await async_sql_call_toolbar_model()
 
         self.assertEqual(len(self.panel._queries), 0)
+
+    @override_settings(
+        DEBUG_TOOLBAR_CONFIG={
+            "SKIP_TOOLBAR_QUERIES": True,
+            "TOOLBAR_STORE_CLASS": "debug_toolbar.store.DatabaseStore",
+        }
+    )
+    def test_toolbar_model_query_quoted_is_not_tracked(self):
+        """
+        Test that a query containing the quoted toolbar model table name is
+        properly skipped from tracking when SKIP_TOOLBAR_QUERIES is True.
+        """
+        self.assertEqual(len(self.panel._queries), 0)
+
+        table = HistoryEntry._meta.db_table
+        quoted_table = connection.ops.quote_name(table)
+        sql = f"SELECT * FROM {quoted_table}"
+
+        with connection.cursor() as cursor:
+            # We wrap the cursor execution to test our tracking middleware
+            try:
+                cursor.execute(sql)
+            except DatabaseError:
+                # Table might not exist yet or raise syntax depending on backend/mock,
+                # but the query tracking logic runs during execute before DB raises.
+                pass
+
+        # The query must NOT be tracked
+        self.assertEqual(len(self.panel._queries), 0)
+
+    @override_settings(
+        DEBUG_TOOLBAR_CONFIG={
+            "SKIP_TOOLBAR_QUERIES": False,
+            "TOOLBAR_STORE_CLASS": "debug_toolbar.store.DatabaseStore",
+        }
+    )
+    def test_toolbar_model_query_quoted_is_tracked(self):
+        """
+        Test that a query containing the quoted toolbar model table name is
+        recorded when SKIP_TOOLBAR_QUERIES is False.
+        """
+        self.assertEqual(len(self.panel._queries), 0)
+
+        table = HistoryEntry._meta.db_table
+        quoted_table = connection.ops.quote_name(table)
+        sql = f"SELECT * FROM {quoted_table}"
+
+        patch_tracking_ddt_models()
+
+        with connection.cursor() as cursor:
+            try:
+                cursor.execute(sql)
+            except DatabaseError:
+                pass
+
+        # The query MUST be tracked
+        self.assertEqual(len(self.panel._queries), 1)
+        query = self.panel._queries[0]
+        self.assertIn(quoted_table, query["sql"])
 
     @unittest.skipUnless(
         connection.vendor == "postgresql", "Test valid only on PostgreSQL"
@@ -407,9 +472,16 @@ class SQLPanelTestCase(BaseTestCase):
         ):
             # Django 4.1 started passing true/false back for boolean
             # comparisons in MySQL.
-            # Django 6.1 started passing true/false for all-non
-            # postgres databases.
+            # Django 6.1 started passing true/false for all
+            # non-postgres databases natively supporting it.
             expected_bools = ["Foo", True, False]
+        elif connection.vendor == "oracle":
+            # Oracle 23c+ supports native SQL booleans (True/False).
+            # Oracle 19c coerces booleans to integers (1/0) under the hood.
+            if connection.features.supports_boolean_expr_in_select_clause:
+                expected_bools = ["Foo", True, False]
+            else:
+                expected_bools = ["Foo", 1, 0]
         else:
             expected_bools = ["Foo"]
 
@@ -470,6 +542,10 @@ class SQLPanelTestCase(BaseTestCase):
         self.assertEqual(len(self.panel._queries), 1)
         self.assertEqual(self.panel._queries[0]["params"], [["a", "b'"]])
 
+    @unittest.skipIf(
+        connection.vendor == "oracle",
+        "Oracle does not support comparing BLOB fields using =",
+    )
     def test_binary_param_force_text(self):
         self.assertEqual(len(self.panel._queries), 0)
 

--- a/tests/panels/test_sql_oracle.py
+++ b/tests/panels/test_sql_oracle.py
@@ -1,0 +1,374 @@
+import unittest
+from unittest.mock import MagicMock, PropertyMock, patch
+
+from django.contrib.auth import get_user_model
+from django.db import DatabaseError, connection
+from django.test import SimpleTestCase, TestCase
+
+from debug_toolbar.panels.sql.forms import SQLSelectForm
+from debug_toolbar.panels.sql.oracle_helper import OracleExplainPlanHelper
+
+
+def _make_mock_explain_form(raw_sql, params=None, duration=1.0):
+    """
+    Utility factory helper to construct SQLSelectForm with pre-filled cleaned_data
+    to minimize redundant boilerplate across test cases.
+    """
+    form = SQLSelectForm(data={})
+    form.cleaned_data = {
+        "request_id": "test_request",
+        "djdt_query_id": "test_query",
+        "alias": "default",
+        "query": {
+            "raw_sql": raw_sql,
+            "params": params or [],
+            "vendor": "oracle",
+            "sql": raw_sql,
+            "duration": duration,
+            "alias": "default",
+        },
+    }
+    return form
+
+
+@unittest.skipUnless(connection.vendor == "oracle", "Test valid only on Oracle")
+class OracleExplainTestCase(TestCase):
+    """
+    Tests the refined Oracle explain plan support in SQLSelectForm.
+    """
+
+    def test_oracle_explain_success(self):
+        User = get_user_model()
+        User.objects.get_or_create(username="explain_test_user")
+
+        form = _make_mock_explain_form(
+            raw_sql="SELECT * FROM auth_user WHERE username = %s",
+            params=["explain_test_user"],
+        )
+
+        result, headers = form.explain()
+
+        self.assertEqual(headers, ["PLAN_TABLE_OUTPUT"])
+
+        flat_result = [row[0] for row in result if row and row[0] is not None]
+
+        self.assertTrue(
+            any(
+                "Plan hash value" in line or "Id" in line or "PLAN_TABLE_OUTPUT" in line
+                for line in flat_result
+            ),
+            f"Expected DBMS_XPLAN structure not found in: {flat_result}",
+        )
+
+        self.assertTrue(
+            any("Schema Health & Statistics Audit" in line for line in flat_result)
+        )
+        self.assertTrue(any("Table Statistics:" in line for line in flat_result))
+
+    @patch("debug_toolbar.panels.sql.forms.connections")
+    def test_oracle_explain_graceful_fallback_on_catalog_error(self, mock_connections):
+        mock_cursor = MagicMock()
+        mock_connection = MagicMock()
+        mock_connection.cursor.return_value.__enter__.return_value = mock_cursor
+        mock_connections.__getitem__.return_value = mock_connection
+
+        mock_cursor.fetchall.side_effect = [
+            [("Plan line 1",), ("Plan line 2",)],
+            DatabaseError("Access Denied to PLAN_TABLE"),
+        ]
+        mock_cursor.description = [("PLAN_TABLE_OUTPUT",)]
+
+        form = _make_mock_explain_form(
+            raw_sql="SELECT * FROM employees",
+            duration=10.0,
+        )
+
+        result, headers = form.explain()
+
+        self.assertEqual(headers, ["PLAN_TABLE_OUTPUT"])
+        self.assertEqual(result, [("Plan line 1",), ("Plan line 2",)])
+
+        calls = mock_cursor.execute.call_args_list
+        cleanup_sql = calls[-1][0][0]
+        self.assertEqual(cleanup_sql, "DELETE FROM PLAN_TABLE WHERE statement_id = %s")
+
+    def test_oracle_explain_suppress_query_block_registry(self):
+        User = get_user_model()
+        User.objects.get_or_create(username="explain_test_user")
+
+        form = _make_mock_explain_form(
+            raw_sql="SELECT * FROM auth_user WHERE username = %s",
+            params=["explain_test_user"],
+        )
+
+        with patch.object(
+            OracleExplainPlanHelper, "_oracle_version", new_callable=PropertyMock
+        ) as mock_version:
+            mock_version.return_value = (19,)
+            result, _ = form.explain()
+
+        flat_result = [row[0] for row in result if row and row[0] is not None]
+
+        self.assertNotIn("Query Block Registry:", flat_result)
+
+        self.assertTrue(
+            any("Schema Health & Statistics Audit" in line for line in flat_result)
+        )
+        self.assertTrue(any("Table Statistics:" in line for line in flat_result))
+
+    @patch("debug_toolbar.panels.sql.forms.connections")
+    def test_oracle_explain_null_owner_mapping(self, mock_connections):
+        mock_cursor = MagicMock()
+        mock_connection = MagicMock()
+        mock_connection.cursor.return_value.__enter__.return_value = mock_cursor
+        mock_connections.__getitem__.return_value = mock_connection
+
+        mock_cursor.connection = MagicMock()
+        mock_cursor.connection.username = "scott"
+
+        mock_cursor.fetchall.side_effect = [
+            [("Plan line 1",)],
+            [(None, "EMPLOYEES")],
+            [],
+            [("SCOTT", "EMPLOYEES", 500, 10, 50, "2026-08-07 12:00:00")],
+            [],
+        ]
+        mock_cursor.description = [("PLAN_TABLE_OUTPUT",)]
+
+        form = _make_mock_explain_form(
+            raw_sql="SELECT * FROM employees",
+            duration=10.0,
+        )
+
+        result, _ = form.explain()
+        flat_result = [row[0] for row in result]
+
+        self.assertTrue(any("SCOTT" in line for line in flat_result))
+        self.assertTrue(any("EMPLOYEES" in line for line in flat_result))
+
+    def test_oracle_explain_custom_settings(self):
+        User = get_user_model()
+        User.objects.get_or_create(username="explain_test_user")
+
+        form = _make_mock_explain_form(
+            raw_sql="SELECT * FROM auth_user WHERE username = %s",
+            params=["explain_test_user"],
+        )
+
+        with patch.object(OracleExplainPlanHelper, "include_catalog_audit", new=False):
+            result, _ = form.explain()
+
+        flat_result = [row[0] for row in result if row and row[0] is not None]
+
+        self.assertFalse(
+            any("Schema Health & Statistics Audit" in line for line in flat_result)
+        )
+
+    @patch("debug_toolbar.panels.sql.forms.connections")
+    def test_oracle_explain_cleanup_plan_table_error(self, mock_connections):
+        mock_cursor = MagicMock()
+        mock_connection = MagicMock()
+        mock_connection.cursor.return_value.__enter__.return_value = mock_cursor
+        mock_connections.__getitem__.return_value = mock_connection
+
+        mock_cursor.fetchall.side_effect = [
+            [("Plan line 1",)],
+            [],
+            [],
+        ]
+
+        def execute_side_effect(sql, params=None):
+            if "DELETE FROM PLAN_TABLE" in sql:
+                raise DatabaseError("Mocked DELETE error")
+            return MagicMock()
+
+        mock_cursor.execute.side_effect = execute_side_effect
+        mock_cursor.description = [("PLAN_TABLE_OUTPUT",)]
+
+        form = _make_mock_explain_form(
+            raw_sql="SELECT * FROM employees",
+            duration=10.0,
+        )
+
+        with self.assertLogs(
+            "debug_toolbar.panels.sql.oracle_helper", level="WARNING"
+        ) as cm:
+            result, headers = form.explain()
+
+        self.assertEqual(headers, ["PLAN_TABLE_OUTPUT"])
+        self.assertEqual(result, [("Plan line 1",)])
+        self.assertTrue(
+            any("Failed to clean up PLAN_TABLE" in log for log in cm.output)
+        )
+
+
+class OracleExplainPlanHelperUnitTestCase(SimpleTestCase):
+    """
+    Pure unit tests for OracleExplainPlanHelper independent logic.
+    These tests are database-independent and run natively on any environment (e.g. SQLite).
+    """
+
+    def test_suppress_qbr_with_audit_present(self):
+
+        helper = OracleExplainPlanHelper(cursor=None)
+        raw_result = [
+            ("SELECT * FROM employees",),
+            ("Query Block Registry:",),
+            ("---------------------",),
+            ('  <q o="19"><n>SEL$1</n></q>',),
+            ("Schema Health & Statistics Audit (ALL_TABLES & ALL_INDEXES)",),
+            ("Table Statistics:",),
+        ]
+
+        filtered = helper._suppress_qbr(raw_result)
+        flat_filtered = [row[0] for row in filtered]
+
+        self.assertEqual(
+            flat_filtered,
+            [
+                "SELECT * FROM employees",
+                "Schema Health & Statistics Audit (ALL_TABLES & ALL_INDEXES)",
+                "Table Statistics:",
+            ],
+        )
+
+    def test_suppress_qbr_without_audit_present(self):
+
+        helper = OracleExplainPlanHelper(cursor=None)
+        raw_result = [
+            ("SELECT * FROM employees",),
+            ("Query Block Registry:",),
+            ("---------------------",),
+            ('  <q o="19"><n>SEL$1</n></q>',),
+        ]
+
+        filtered = helper._suppress_qbr(raw_result)
+        flat_filtered = [row[0] for row in filtered]
+
+        self.assertEqual(flat_filtered, ["SELECT * FROM employees"])
+
+    def test_suppress_qbr_no_qbr_present(self):
+
+        helper = OracleExplainPlanHelper(cursor=None)
+        raw_result = [
+            ("SELECT * FROM employees",),
+            ("Plan line 2",),
+        ]
+
+        filtered = helper._suppress_qbr(raw_result)
+        self.assertEqual(filtered, raw_result)
+
+    def test_suppress_qbr_with_note_and_audit_present(self):
+
+        helper = OracleExplainPlanHelper(cursor=None)
+        raw_result = [
+            ("SELECT * FROM employees",),
+            ("Note",),
+            ("-----",),
+            ("  - dynamic sampling used",),
+            ("Query Block Registry:",),
+            ("---------------------",),
+            ('  <q o="19"><n>SEL$1</n></q>',),
+            ("Schema Health & Statistics Audit (ALL_TABLES & ALL_INDEXES)",),
+            ("Table Statistics:",),
+        ]
+
+        filtered = helper._suppress_qbr(raw_result)
+        flat_filtered = [row[0] for row in filtered]
+
+        self.assertEqual(
+            flat_filtered,
+            [
+                "SELECT * FROM employees",
+                "Note",
+                "-----",
+                "  - dynamic sampling used",
+                "Schema Health & Statistics Audit (ALL_TABLES & ALL_INDEXES)",
+                "Table Statistics:",
+            ],
+        )
+
+    def test_render_stats_as_ascii_empty_inputs(self):
+
+        helper = OracleExplainPlanHelper(cursor=None)
+        lines = helper._render_stats_as_ascii([], [])
+        self.assertEqual(lines, [])
+
+    def test_get_involved_tables_without_cursor_connection_metadata(self):
+        """
+        Cover fallback paths for cursors that don't expose the wrapped driver
+        connection metadata and for index mappings without table names. Django's
+        Oracle cursor exposes metadata, but the helper is defensive.
+        """
+
+        class CursorWithoutConnectionMetadata:
+            cursor = object()
+
+            def __init__(self):
+                self.calls = 0
+
+            def execute(self, sql, params):
+                self.calls += 1
+
+            def fetchall(self):
+                if self.calls == 1:
+                    return [("DEFAULT_TEST", "AUTH_USER"), (None, None)]
+                if self.calls == 2:
+                    return [("DEFAULT_TEST", "AUTH_USER_USERNAME_IDX")]
+                return [("DEFAULT_TEST", None)]
+
+        helper = OracleExplainPlanHelper(CursorWithoutConnectionMetadata())
+        self.assertEqual(
+            helper._get_involved_tables("stmt"), {("DEFAULT_TEST", "AUTH_USER")}
+        )
+
+
+@unittest.skipUnless(connection.vendor == "oracle", "Test valid only on Oracle")
+class OracleExplainPlanHelperDBTestCase(TestCase):
+    """
+    Database-dependent integration tests for OracleExplainPlanHelper.
+    Requires a running Oracle database.
+    """
+
+    def test_get_involved_tables_reverse_maps_index_to_table(self):
+        """
+        Exercise the real Oracle PLAN_TABLE -> ALL_INDEXES reverse mapping.
+
+        Oracle execution plans can contain only index nodes for indexed lookups.
+        The helper must map those indexes back to their parent tables so the
+        catalog audit still reports table statistics.
+        """
+
+        get_user_model().objects.get_or_create(username="indexed_plan_user")
+
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT owner, index_name, table_owner, table_name "
+                "FROM all_indexes "
+                "WHERE table_owner = USER "
+                "AND table_name = %s "
+                "AND ROWNUM = 1",
+                [get_user_model()._meta.db_table.upper()],
+            )
+            index_row = cursor.fetchone()
+            self.assertIsNotNone(index_row)
+            index_owner, index_name, table_owner, table_name = index_row
+
+            stmt_id = "dt_test_index_mapping"
+            cursor.execute("DELETE FROM PLAN_TABLE WHERE statement_id = %s", [stmt_id])
+            try:
+                cursor.execute(
+                    "INSERT INTO PLAN_TABLE "
+                    "(statement_id, object_owner, object_name, object_type) "
+                    "VALUES (%s, %s, %s, %s)",
+                    [stmt_id, index_owner, index_name, "INDEX"],
+                )
+
+                helper = OracleExplainPlanHelper(cursor)
+                table_keys = helper._get_involved_tables(stmt_id)
+
+                self.assertIn((table_owner, table_name), table_keys)
+            finally:
+                cursor.execute(
+                    "DELETE FROM PLAN_TABLE WHERE statement_id = %s", [stmt_id]
+                )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,10 +1,12 @@
 import os
 import re
 import unittest
+import uuid
 import warnings
 from unittest.mock import patch
 
 import html5lib
+from django.contrib.auth import get_user_model
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from django.core import signing
 from django.core.cache import cache
@@ -587,6 +589,58 @@ class DebugToolbarIntegrationTestCase(IntegrationTestCase):
         }
         response = self.client.post(url, data)
         self.assertEqual(response.status_code, 200)
+
+    @unittest.skipUnless(connection.vendor == "oracle", "Test valid only on Oracle")
+    def test_sql_explain_oracle_success(self):
+        """
+        End-to-end integration test of Oracle explain plan rendering.
+        Induces CBO index scan by searching User by username unique field.
+        """
+        User = get_user_model()
+        User.objects.get_or_create(username="explain_test_user")
+
+        self.client.get("/execute_sql/")
+        request_ids = list(get_store().request_ids())
+        request_id = request_ids[-1]
+        toolbar = DebugToolbar.fetch(request_id, SQLPanel.panel_id)
+        panel = toolbar.get_panel_by_id(SQLPanel.panel_id)
+
+        # Inject a query with index lookup into SQLPanel store and save back to store
+        sql = "SELECT id FROM auth_user WHERE username = 'explain_test_user'"
+        stats = panel.get_stats()
+        queries = stats.setdefault("queries", [])
+
+        djdt_query_id = uuid.uuid4().hex
+        queries.append(
+            {
+                "djdt_query_id": djdt_query_id,
+                "sql": sql,
+                "raw_sql": sql,
+                "params": [],
+                "duration": 1.0,
+                "alias": "default",
+                "vendor": "oracle",
+            }
+        )
+        panel.record_stats(stats)
+
+        url = "/__debug__/sql_explain/"
+        data = {
+            "signed": SignedDataForm.sign(
+                {
+                    "request_id": request_id,
+                    "djdt_query_id": djdt_query_id,
+                }
+            )
+        }
+
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, 200)
+        content = response.json()["content"]
+        self.assertIn("PLAN_TABLE_OUTPUT", content)
+        self.assertIn("Schema Health &amp; Statistics Audit", content)
+        self.assertIn("Table Statistics:", content)
+        self.assertIn("Index Statistics &amp; Status:", content)
 
     def test_sql_profile_checks_show_toolbar(self):
         self.client.get("/execute_sql/")

--- a/tests/test_integration_async.py
+++ b/tests/test_integration_async.py
@@ -1,8 +1,11 @@
 import re
 import unittest
+import uuid
 from unittest.mock import patch
 
 import html5lib
+from asgiref.sync import sync_to_async
+from django.contrib.auth import get_user_model
 from django.core import signing
 from django.core.cache import cache
 from django.db import connection
@@ -431,6 +434,58 @@ class DebugToolbarIntegrationTestCase(IntegrationTestCase):
         with self.settings(INTERNAL_IPS=[]):
             response = await self.async_client.post(url, data)
             self.assertEqual(response.status_code, 404)
+
+    @unittest.skipUnless(connection.vendor == "oracle", "Test valid only on Oracle")
+    async def test_sql_explain_oracle_success_async(self):
+        """
+        End-to-end asynchronous integration test of Oracle explain plan rendering.
+        Induces CBO index scan by searching User by username unique field.
+        """
+        User = get_user_model()
+        await sync_to_async(User.objects.get_or_create)(username="explain_test_user")
+
+        await self.async_client.get("/execute_sql/")
+        request_ids = list(get_store().request_ids())
+        request_id = request_ids[-1]
+        toolbar = DebugToolbar.fetch(request_id, SQLPanel.panel_id)
+        panel = toolbar.get_panel_by_id(SQLPanel.panel_id)
+
+        # Inject a query with index lookup into SQLPanel store and save back to store
+        sql = "SELECT id FROM auth_user WHERE username = 'explain_test_user'"
+        stats = panel.get_stats()
+        queries = stats.setdefault("queries", [])
+
+        djdt_query_id = uuid.uuid4().hex
+        queries.append(
+            {
+                "djdt_query_id": djdt_query_id,
+                "sql": sql,
+                "raw_sql": sql,
+                "params": [],
+                "duration": 1.0,
+                "alias": "default",
+                "vendor": "oracle",
+            }
+        )
+        panel.record_stats(stats)
+
+        url = "/__debug__/sql_explain/"
+        data = {
+            "signed": SignedDataForm.sign(
+                {
+                    "request_id": request_id,
+                    "djdt_query_id": djdt_query_id,
+                }
+            )
+        }
+
+        response = await self.async_client.post(url, data)
+        self.assertEqual(response.status_code, 200)
+        content = response.json()["content"]
+        self.assertIn("PLAN_TABLE_OUTPUT", content)
+        self.assertIn("Schema Health &amp; Statistics Audit", content)
+        self.assertIn("Table Statistics:", content)
+        self.assertIn("Index Statistics &amp; Status:", content)
 
     async def test_sql_profile_checks_show_toolbar(self):
         await self.async_client.get("/execute_sql/")

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,13 @@
 [tox]
+min_version = 4.58
 isolated_build = true
 envlist =
     docs
     packaging
-    py{310,311}-dj{52}-{sqlite,postgresql,psycopg3,postgis,mysql}
-    py{312}-dj{52,60,61}-{sqlite,postgresql,psycopg3,postgis,mysql}
-    py{313}-dj{52,60,61,main}-{sqlite,psycopg3,postgis3,mysql}
-    py{314}-dj{52,60,61,main}-{sqlite,psycopg3,postgis3,mysql}
+    py{310,311}-dj{52}-{sqlite,postgresql,psycopg3,postgis,mysql,oracle}
+    py{312}-dj{52,60,61}-{sqlite,postgresql,psycopg3,postgis,mysql,oracle}
+    py{313}-dj{52,60,61,main}-{sqlite,psycopg3,postgis3,mysql,oracle}
+    py{314}-dj{52,60,61,main}-{sqlite,psycopg3,postgis3,mysql,oracle}
 
 [testenv]
 deps =
@@ -19,6 +20,7 @@ deps =
     postgis: psycopg2-binary
     postgis3: psycopg[binary]
     mysql: mysqlclient
+    oracle: oracledb
 passenv=
     CI
     COVERAGE_ARGS
@@ -48,11 +50,14 @@ setenv =
     DB_HOST = {env:DB_HOST:localhost}
     DB_PASSWORD =  {env:DB_PASSWORD:debug_toolbar}
     DJANGO_SETTINGS_MODULE = tests.settings
+    COVERAGE_FILE = {env:COVERAGE_FILE:.coverage.{envname}}
 allowlist_externals = make
 pip_pre = True
 dependency_groups =
     dev
-commands = python -b -m coverage run -m django test -v2 {posargs:tests}
+commands =
+    python -b -m coverage run -m django test -v2 {posargs:tests}
+    python -b -m coverage report -m --fail-under=70
 
 
 [testenv:py{310,311,312,313,314}-dj{52,60,61,main}-{postgresql,psycopg3}]
@@ -81,6 +86,17 @@ setenv =
     {[testenv]setenv}
     DB_BACKEND = sqlite3
     DB_NAME = ":memory:"
+
+
+[testenv:py{310,311,312,313,314}-dj{52,60,61,main}-oracle]
+setenv =
+    {[testenv]setenv}
+    DB_BACKEND = oracle
+    DB_NAME = {env:DB_NAME:localhost:1521/FREEPDB1}
+    DB_USER = {env:DB_USER:system}
+    DB_PASSWORD = {env:DB_PASSWORD:oracle_secret_pass}
+    DB_HOST = {env:DB_HOST:}
+    DB_PORT = {env:DB_PORT:}
 
 
 [testenv:docs]
@@ -113,3 +129,18 @@ DB_BACKEND =
     postgis: postgis
     postgis3: postgis3
     sqlite3: sqlite
+    oracle: oracle
+
+
+[testenv:coverage-clean]
+deps = coverage
+skip_install = true
+commands = python -m coverage erase
+
+
+[testenv:coverage-report]
+deps = coverage
+skip_install = true
+commands =
+    python -c "import os, glob; os.system('python -m coverage combine') if glob.glob('.coverage.*') else None"
+    python -m coverage report -m


### PR DESCRIPTION
#### Problem:

 django-debug-toolbar returns an HTTP 500 error when attempting to use the Explain panel with Oracle.


<details>

<summary> <b>Click here to display the source of error when using with Oracle</b> </summary>

```
The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/luzfcb/.virtualenvs/myprojectenv-3.12/lib/python3.12/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/home/luzfcb/.virtualenvs/myprojectenv-3.12/lib/python3.12/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/luzfcb/.virtualenvs/myprojectenv-3.12/lib/python3.12/site-packages/django/views/decorators/csrf.py", line 65, in _view_wrapper
    return view_func(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/luzfcb/.virtualenvs/myprojectenv-3.12/lib/python3.12/site-packages/debug_toolbar/decorators.py", line 34, in inner
    return view(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/luzfcb/.virtualenvs/myprojectenv-3.12/lib/python3.12/site-packages/debug_toolbar/decorators.py", line 46, in inner
    return view(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/luzfcb/.virtualenvs/myprojectenv-3.12/lib/python3.12/site-packages/debug_toolbar/panels/sql/views.py", line 61, in sql_explain
    result, headers = form.explain()
                      ^^^^^^^^^^^^^^
  File "/home/luzfcb/.virtualenvs/myprojectenv-3.12/lib/python3.12/site-packages/debug_toolbar/panels/sql/forms.py", line 83, in explain
    cursor.execute(f"EXPLAIN {sql}", params)
  File "/home/luzfcb/.virtualenvs/myprojectenv-3.12/lib/python3.12/site-packages/django/db/backends/utils.py", line 122, in execute
    return super().execute(sql, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/luzfcb/.virtualenvs/myprojectenv-3.12/lib/python3.12/site-packages/django/db/backends/utils.py", line 79, in execute
    return self._execute_with_wrappers(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/luzfcb/.virtualenvs/myprojectenv-3.12/lib/python3.12/site-packages/django/db/backends/utils.py", line 92, in _execute_with_wrappers
    return executor(sql, params, many, context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/luzfcb/.virtualenvs/myprojectenv-3.12/lib/python3.12/site-packages/django/db/backends/utils.py", line 100, in _execute
    with self.db.wrap_database_errors:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/luzfcb/.virtualenvs/myprojectenv-3.12/lib/python3.12/site-packages/django/db/utils.py", line 91, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "/home/luzfcb/.virtualenvs/myprojectenv-3.12/lib/python3.12/site-packages/django/db/backends/utils.py", line 105, in _execute
    return self.cursor.execute(sql, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/luzfcb/.virtualenvs/myprojectenv-3.12/lib/python3.12/site-packages/django/db/backends/oracle/base.py", line 633, in execute
    return self.cursor.execute(query, self._param_generator(params))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/luzfcb/.virtualenvs/myprojectenv-3.12/lib/python3.12/site-packages/oracledb/cursor.py", line 708, in execute
    impl.execute(self)
  File "src/oracledb/impl/thin/cursor.pyx", line 277, in oracledb.thin_impl.ThinCursorImpl.execute
  File "src/oracledb/impl/thin/protocol.pyx", line 482, in oracledb.thin_impl.Protocol._process_single_message
  File "src/oracledb/impl/thin/protocol.pyx", line 483, in oracledb.thin_impl.Protocol._process_single_message
  File "src/oracledb/impl/thin/protocol.pyx", line 475, in oracledb.thin_impl.Protocol._process_message
  File "src/oracledb/impl/thin/messages/base.pyx", line 102, in oracledb.thin_impl.Message._check_and_raise_exception
django.db.utils.DatabaseError: ORA-00905: missing keyword
Help: https://docs.oracle.com/error-help/db/ora-00905/

```
</details>


#### Description

This PR solves the issue by introducing initial support for Oracle Database to django-debug-toolbar's SQL Explain panel, closing the 14-year-old issue #227.

Unlike databases that support single-step integrated query analysis (such as PostgreSQL's "EXPLAIN ANALYZE"), Oracle requires a multi-step orchestration workflow to execute an explain plan and format its output securely without session pollution.

Key Features & Implementations:

1. **Oracle SQL Explain Orchestration:**
   - Introduced `OracleExplainPlanHelper` to encapsulate and run the multi-step `EXPLAIN PLAN` and `DBMS_XPLAN.DISPLAY` lifecycle.
   - Clean up temporary rows from `PLAN_TABLE` at the end of execution.
   - Suppress Query Block Registry (QBR) XML output on legacy Oracle connections (< 21) to prevent memory exhaustion and infinite recursion bugs on some markdown parsers of some LLM cli.
   - Include a schema health audit fallback that queries `ALL_TABLES` and `ALL_INDEXES` metadata to format and append table and index statistics (sizes, status, performance counters) as aligned ASCII tables.

2. **Query Tracking and Toolbar Integration:**
   - Updated `debug_toolbar/panels/sql/forms.py` to hook `SQLSelectForm` and delegate select-explain execution to the new Oracle helper.
   - Updated `debug_toolbar/panels/sql/tracking.py` to filter out toolbar queries using vendor-specific quoting (`quote_name`).

3. **Infrastructure & CI/CD:**
   - Expanded `docker-compose.yml` to provision local PostgreSQL, MariaDB, and Oracle Database Free containers for multi-backend testing.
   - Integrated Oracle Database test job in `.github/workflows/test.yml` and `tox.ini` with isolated test/coverage databases.

4. **Testing:**
   - Added `tests/panels/test_sql_oracle.py` with rigorous unit and mocking coverage.
   - Updated integration tests for synchronous and asynchronous contexts.





<details>

<summary> **Click here to display how Explain will looks like on Oracle** </summary>

### Screenshot
<img width="926" height="3449" alt="sql_explain_oracle" src="https://github.com/user-attachments/assets/10d02ec5-f413-4018-8da5-c003b9f59921" />

### A real report

```
Plan hash value: 843816195
 
-----------------------------------------------------------------------------------------------------------------------
| Id  | Operation                               | Name                        | Rows  | Bytes | Cost (%CPU)| Time     |
-----------------------------------------------------------------------------------------------------------------------
|   0 | SELECT STATEMENT                        |                             |    10 | 54340 |    15   (7)| 00:00:01 |
|*  1 |  VIEW                                   |                             |    10 | 54340 |    15   (7)| 00:00:01 |
|*  2 |   WINDOW SORT PUSHED RANK               |                             |   105 | 43680 |    15   (7)| 00:00:01 |
|*  3 |    HASH JOIN RIGHT OUTER                |                             |   105 | 43680 |    14   (0)| 00:00:01 |
|   4 |     TABLE ACCESS FULL                   | DJANGO_CONTENT_TYPE         |    31 |  1271 |     4   (0)| 00:00:01 |
|   5 |     NESTED LOOPS                        |                             |   105 | 39375 |    10   (0)| 00:00:01 |
|   6 |      TABLE ACCESS BY INDEX ROWID        | AUTH_USER                   |     1 |   166 |     2   (0)| 00:00:01 |
|*  7 |       INDEX UNIQUE SCAN                 | SYS_C0032863                |     1 |       |     1   (0)| 00:00:01 |
|   8 |      TABLE ACCESS BY INDEX ROWID BATCHED| DJANGO_ADMIN_LOG            |   105 | 21945 |     8   (0)| 00:00:01 |
|*  9 |       INDEX RANGE SCAN                  | DJANGO_ADM_USER_ID_C564EBA6 |   105 |       |     1   (0)| 00:00:01 |
-----------------------------------------------------------------------------------------------------------------------
 
Query Block Name / Object Alias (identified by operation id):
-------------------------------------------------------------
 
   1 - SEL$2B60952E / from$_subquery$_006@SEL$4
   2 - SEL$2B60952E
   4 - SEL$2B60952E / DJANGO_CONTENT_TYPE@SEL$2
   6 - SEL$2B60952E / AUTH_USER@SEL$1
   7 - SEL$2B60952E / AUTH_USER@SEL$1
   8 - SEL$2B60952E / DJANGO_ADMIN_LOG@SEL$1
   9 - SEL$2B60952E / DJANGO_ADMIN_LOG@SEL$1
 
Outline Data
-------------
 
  /*+
      BEGIN_OUTLINE_DATA
      SWAP_JOIN_INPUTS(@"SEL$2B60952E" "DJANGO_CONTENT_TYPE"@"SEL$2")
      USE_HASH(@"SEL$2B60952E" "DJANGO_CONTENT_TYPE"@"SEL$2")
      USE_NL(@"SEL$2B60952E" "DJANGO_ADMIN_LOG"@"SEL$1")
      LEADING(@"SEL$2B60952E" "AUTH_USER"@"SEL$1" "DJANGO_ADMIN_LOG"@"SEL$1" "DJANGO_CONTENT_TYPE"@"SEL$2")
      FULL(@"SEL$2B60952E" "DJANGO_CONTENT_TYPE"@"SEL$2")
      BATCH_TABLE_ACCESS_BY_ROWID(@"SEL$2B60952E" "DJANGO_ADMIN_LOG"@"SEL$1")
      INDEX_RS_ASC(@"SEL$2B60952E" "DJANGO_ADMIN_LOG"@"SEL$1" ("DJANGO_ADMIN_LOG"."USER_ID"))
      INDEX_RS_ASC(@"SEL$2B60952E" "AUTH_USER"@"SEL$1" ("AUTH_USER"."ID"))
      NO_ACCESS(@"SEL$4" "from$_subquery$_006"@"SEL$4")
      OUTLINE(@"SEL$2")
      OUTLINE(@"SEL$1")
      ANSI_REARCH(@"SEL$2")
      OUTLINE(@"SEL$1A566D0B")
      OUTLINE(@"SEL$3")
      MERGE(@"SEL$1" >"SEL$1A566D0B")
      OUTLINE(@"SEL$8B0CE372")
      ANSI_REARCH(@"SEL$3")
      OUTLINE(@"SEL$F52A8B21")
      OUTLINE_LEAF(@"SEL$4")
      MERGE(@"SEL$8B0CE372" >"SEL$F52A8B21")
      OUTLINE_LEAF(@"SEL$2B60952E")
      ALL_ROWS
      DB_VERSION('19.1.0')
      OPTIMIZER_FEATURES_ENABLE('19.1.0')
      IGNORE_OPTIM_EMBEDDED_HINTS
      END_OUTLINE_DATA
  */
 
Predicate Information (identified by operation id):
---------------------------------------------------
 
   1 - filter("from$_subquery$_006"."rowlimit_$$_rownumber"<=10)
   2 - filter(ROW_NUMBER() OVER ( ORDER BY INTERNAL_FUNCTION("DJANGO_ADMIN_LOG"."ACTION_TIME") DESC )<=10)
   3 - access("DJANGO_ADMIN_LOG"."CONTENT_TYPE_ID"="DJANGO_CONTENT_TYPE"."ID"(+))
   7 - access("AUTH_USER"."ID"=:ARG0)
   9 - access("DJANGO_ADMIN_LOG"."USER_ID"=:ARG0)
 
Column Projection Information (identified by operation id):
-----------------------------------------------------------
 
   1 - "from$_subquery$_006"."ITEM_0"[NUMBER,22], "from$_subquery$_006"."ITEM_1"[TIMESTAMP,11], 
       "from$_subquery$_006"."ITEM_2"[NUMBER,22], "from$_subquery$_006"."ITEM_3"[NUMBER,22], 
       "from$_subquery$_006"."ITEM_4"[LOB,4000], "from$_subquery$_006"."ITEM_5"[NVARCHAR2,400], 
       "from$_subquery$_006"."ITEM_6"[NUMBER,22], "from$_subquery$_006"."ITEM_7"[LOB,4000], 
       "from$_subquery$_006"."ITEM_8"[NUMBER,22], "from$_subquery$_006"."ITEM_9"[NVARCHAR2,256], 
       "from$_subquery$_006"."ITEM_10"[TIMESTAMP,11], "from$_subquery$_006"."ITEM_11"[NUMBER,22], 
       "from$_subquery$_006"."ITEM_12"[NVARCHAR2,300], "from$_subquery$_006"."ITEM_13"[NVARCHAR2,300], 
       "from$_subquery$_006"."ITEM_14"[NVARCHAR2,300], "from$_subquery$_006"."ITEM_15"[NVARCHAR2,508], 
       "from$_subquery$_006"."ITEM_16"[NUMBER,22], "from$_subquery$_006"."ITEM_17"[NUMBER,22], 
       "from$_subquery$_006"."ITEM_18"[TIMESTAMP,11], "from$_subquery$_006"."ITEM_19"[NUMBER,22], 
       "from$_subquery$_006"."ITEM_20"[NVARCHAR2,200], "from$_subquery$_006"."ITEM_21"[NVARCHAR2,200], 
       "from$_subquery$_006"."rowlimit_$$_rownumber"[NUMBER,22]
   2 - (#keys=1) INTERNAL_FUNCTION("DJANGO_ADMIN_LOG"."ACTION_TIME")[11], 
       "DJANGO_CONTENT_TYPE"."ID"[NUMBER,22], "DJANGO_ADMIN_LOG"."CONTENT_TYPE_ID"[NUMBER,22], 
       "DJANGO_CONTENT_TYPE"."MODEL"[NVARCHAR2,200], "DJANGO_CONTENT_TYPE"."APP_LABEL"[NVARCHAR2,200], 
       "AUTH_USER".ROWID[ROWID,10], "AUTH_USER"."ID"[NUMBER,22], "AUTH_USER"."PASSWORD"[NVARCHAR2,256], 
       "AUTH_USER"."LAST_LOGIN"[TIMESTAMP,11], "AUTH_USER"."IS_SUPERUSER"[NUMBER,22], 
       "AUTH_USER"."USERNAME"[NVARCHAR2,300], "AUTH_USER"."FIRST_NAME"[NVARCHAR2,300], 
       "AUTH_USER"."LAST_NAME"[NVARCHAR2,300], "AUTH_USER"."EMAIL"[NVARCHAR2,508], "AUTH_USER"."IS_STAFF"[NUMBER,22], 
       "AUTH_USER"."IS_ACTIVE"[NUMBER,22], "AUTH_USER"."DATE_JOINED"[TIMESTAMP,11], 
       "DJANGO_ADMIN_LOG".ROWID[ROWID,10], "DJANGO_ADMIN_LOG"."ID"[NUMBER,22], 
       "DJANGO_ADMIN_LOG"."USER_ID"[NUMBER,22], "DJANGO_ADMIN_LOG"."OBJECT_ID"[LOB,4000], 
       "DJANGO_ADMIN_LOG"."OBJECT_REPR"[NVARCHAR2,400], "DJANGO_ADMIN_LOG"."ACTION_FLAG"[NUMBER,22], 
       "DJANGO_ADMIN_LOG"."CHANGE_MESSAGE"[LOB,4000], ROW_NUMBER() OVER ( ORDER BY 
       INTERNAL_FUNCTION("DJANGO_ADMIN_LOG"."ACTION_TIME") DESC )[22]
   3 - (#keys=1) "DJANGO_CONTENT_TYPE"."ID"[NUMBER,22], "DJANGO_ADMIN_LOG"."CONTENT_TYPE_ID"[NUMBER,22], 
       "DJANGO_CONTENT_TYPE"."MODEL"[NVARCHAR2,200], "DJANGO_CONTENT_TYPE"."APP_LABEL"[NVARCHAR2,200], 
       "AUTH_USER".ROWID[ROWID,10], "AUTH_USER"."ID"[NUMBER,22], "AUTH_USER"."PASSWORD"[NVARCHAR2,256], 
       "AUTH_USER"."LAST_LOGIN"[TIMESTAMP,11], "AUTH_USER"."IS_SUPERUSER"[NUMBER,22], 
       "AUTH_USER"."USERNAME"[NVARCHAR2,300], "AUTH_USER"."FIRST_NAME"[NVARCHAR2,300], 
       "AUTH_USER"."LAST_NAME"[NVARCHAR2,300], "AUTH_USER"."EMAIL"[NVARCHAR2,508], "AUTH_USER"."IS_STAFF"[NUMBER,22], 
       "AUTH_USER"."IS_ACTIVE"[NUMBER,22], "AUTH_USER"."DATE_JOINED"[TIMESTAMP,11], 
       "DJANGO_ADMIN_LOG".ROWID[ROWID,10], "DJANGO_ADMIN_LOG"."ID"[NUMBER,22], 
       "DJANGO_ADMIN_LOG"."ACTION_TIME"[TIMESTAMP,11], "DJANGO_ADMIN_LOG"."OBJECT_ID"[LOB,4000], 
       "DJANGO_ADMIN_LOG"."OBJECT_REPR"[NVARCHAR2,400], "DJANGO_ADMIN_LOG"."ACTION_FLAG"[NUMBER,22], 
       "DJANGO_ADMIN_LOG"."CHANGE_MESSAGE"[LOB,4000], "DJANGO_ADMIN_LOG"."USER_ID"[NUMBER,22]
   4 - (rowset=256) "DJANGO_CONTENT_TYPE"."ID"[NUMBER,22], "DJANGO_CONTENT_TYPE"."APP_LABEL"[NVARCHAR2,200], 
       "DJANGO_CONTENT_TYPE"."MODEL"[NVARCHAR2,200]
   5 - (#keys=0) "AUTH_USER".ROWID[ROWID,10], "AUTH_USER"."ID"[NUMBER,22], 
       "AUTH_USER"."PASSWORD"[NVARCHAR2,256], "AUTH_USER"."LAST_LOGIN"[TIMESTAMP,11], 
       "AUTH_USER"."IS_SUPERUSER"[NUMBER,22], "AUTH_USER"."USERNAME"[NVARCHAR2,300], 
       "AUTH_USER"."FIRST_NAME"[NVARCHAR2,300], "AUTH_USER"."LAST_NAME"[NVARCHAR2,300], 
       "AUTH_USER"."EMAIL"[NVARCHAR2,508], "AUTH_USER"."IS_STAFF"[NUMBER,22], "AUTH_USER"."IS_ACTIVE"[NUMBER,22], 
       "AUTH_USER"."DATE_JOINED"[TIMESTAMP,11], "DJANGO_ADMIN_LOG".ROWID[ROWID,10], 
       "DJANGO_ADMIN_LOG"."ID"[NUMBER,22], "DJANGO_ADMIN_LOG"."ACTION_TIME"[TIMESTAMP,11], 
       "DJANGO_ADMIN_LOG"."OBJECT_ID"[LOB,4000], "DJANGO_ADMIN_LOG"."OBJECT_REPR"[NVARCHAR2,400], 
       "DJANGO_ADMIN_LOG"."ACTION_FLAG"[NUMBER,22], "DJANGO_ADMIN_LOG"."CHANGE_MESSAGE"[LOB,4000], 
       "DJANGO_ADMIN_LOG"."CONTENT_TYPE_ID"[NUMBER,22], "DJANGO_ADMIN_LOG"."USER_ID"[NUMBER,22]
   6 - "AUTH_USER".ROWID[ROWID,10], "AUTH_USER"."ID"[NUMBER,22], "AUTH_USER"."PASSWORD"[NVARCHAR2,256], 
       "AUTH_USER"."LAST_LOGIN"[TIMESTAMP,11], "AUTH_USER"."IS_SUPERUSER"[NUMBER,22], 
       "AUTH_USER"."USERNAME"[NVARCHAR2,300], "AUTH_USER"."FIRST_NAME"[NVARCHAR2,300], 
       "AUTH_USER"."LAST_NAME"[NVARCHAR2,300], "AUTH_USER"."EMAIL"[NVARCHAR2,508], "AUTH_USER"."IS_STAFF"[NUMBER,22], 
       "AUTH_USER"."IS_ACTIVE"[NUMBER,22], "AUTH_USER"."DATE_JOINED"[TIMESTAMP,11]
   7 - "AUTH_USER".ROWID[ROWID,10], "AUTH_USER"."ID"[NUMBER,22]
   8 - "DJANGO_ADMIN_LOG".ROWID[ROWID,10], "DJANGO_ADMIN_LOG"."ID"[NUMBER,22], 
       "DJANGO_ADMIN_LOG"."ACTION_TIME"[TIMESTAMP,11], "DJANGO_ADMIN_LOG"."OBJECT_ID"[LOB,4000], 
       "DJANGO_ADMIN_LOG"."OBJECT_REPR"[NVARCHAR2,400], "DJANGO_ADMIN_LOG"."ACTION_FLAG"[NUMBER,22], 
       "DJANGO_ADMIN_LOG"."CHANGE_MESSAGE"[LOB,4000], "DJANGO_ADMIN_LOG"."CONTENT_TYPE_ID"[NUMBER,22], 
       "DJANGO_ADMIN_LOG"."USER_ID"[NUMBER,22]
   9 - "DJANGO_ADMIN_LOG".ROWID[ROWID,10], "DJANGO_ADMIN_LOG"."USER_ID"[NUMBER,22]
 
Schema Health & Statistics Audit (ALL_TABLES & ALL_INDEXES)
================================================================
Table Statistics:
+-----------------+--------------------------------+------------+------------+-------------+---------------------+
| Owner           | Table Name                     | Num Rows   | Blocks     | Avg Row Len | Last Analyzed       |
+-----------------+--------------------------------+------------+------------+-------------+---------------------+
| DUSER           | AUTH_USER                      | 712        | 22         | 166         | 2026-06-05 22:01:29 |
| DUSER           | DJANGO_ADMIN_LOG               | 840        | 30         | 209         | 2026-05-27 22:00:10 |
| DUSER           | DJANGO_CONTENT_TYPE            | 31         | 8          | 41          | 2026-07-04 14:03:27 |
+-----------------+--------------------------------+------------+------------+-------------+---------------------+

Index Statistics & Status:
+-----------------+--------------------------------+---------------------------+------------+----------+---------------------+
| Owner           | Index Name                     | Table Name                | Uniqueness | Status   | Last Analyzed       |
+-----------------+--------------------------------+---------------------------+------------+----------+---------------------+
| DUSER           | SYS_C0032862                   | AUTH_USER                 | UNIQUE     | VALID    | 2026-06-05 22:01:29 |
| DUSER           | SYS_C0032863                   | AUTH_USER                 | UNIQUE     | VALID    | 2026-06-05 22:01:29 |
| DUSER           | DJANGO_ADM_CONTENT_TY_C4BCE8EB | DJANGO_ADMIN_LOG          | NONUNIQUE  | VALID    | 2026-05-27 22:00:10 |
| DUSER           | DJANGO_ADM_USER_ID_C564EBA6    | DJANGO_ADMIN_LOG          | NONUNIQUE  | VALID    | 2026-05-27 22:00:10 |
| DUSER           | SYS_C0032847                   | DJANGO_ADMIN_LOG          | UNIQUE     | VALID    | 2026-05-27 22:00:10 |
| DUSER           | DJANGO_CO_APP_LABEL_76BD3D3B_U | DJANGO_CONTENT_TYPE       | UNIQUE     | VALID    | 2026-07-04 14:03:27 |
| DUSER           | SYS_C0032820                   | DJANGO_CONTENT_TYPE       | UNIQUE     | VALID    | 2026-07-04 14:03:27 |
+-----------------+--------------------------------+---------------------------+------------+----------+---------------------+

```


</details>





#### Checklist:

- [x] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.

#### AI/LLM Usage
- [x] This PR includes code generated with the help of an AI/LLM


