### PR TITLE
Stop a JSON key named items breaking the History panel

### DIFF
--- a/debug_toolbar/templates/debug_toolbar/panels/history_tr.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/history_tr.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n debug_toolbar %}
 <tr class="{% if request_id == current_request_id %}djdt-highlighted{% endif %}" id="historyMain_{{ request_id }}" data-request-id="{{ request_id }}">
     <td>
         {{ history_context.history_stats.time|escape }}
@@ -24,7 +24,7 @@
               </tr>
             </thead>
             <tbody>
-              {% for key, value in history_context.history_stats.data.items %}
+              {% for key, value in history_context.history_stats.data|dict_items %}
                 <tr>
                   <td><code>{{ key|pprint }}</code></td>
                   <td><code>{{ value|pprint }}</code></td>

--- a/debug_toolbar/templates/debug_toolbar/panels/history_tr.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/history_tr.html
@@ -1,4 +1,4 @@
-{% load i18n debug_toolbar %}
+{% load debug_toolbar i18n %}
 <tr class="{% if request_id == current_request_id %}djdt-highlighted{% endif %}" id="historyMain_{{ request_id }}" data-request-id="{{ request_id }}">
     <td>
         {{ history_context.history_stats.time|escape }}

--- a/debug_toolbar/templatetags/debug_toolbar.py
+++ b/debug_toolbar/templatetags/debug_toolbar.py
@@ -17,6 +17,29 @@ def _svg_contents(path):
         return handle.read().strip()
 
 
+@register.filter
+def dict_items(value):
+    """
+    Return a mapping's ``(key, value)`` pairs.
+
+    ``{% for k, v in mapping.items %}`` is unsafe when the keys come from user
+    input. Django resolves ``mapping.items`` with a dictionary lookup before it
+    tries attribute lookup, so a key literally named ``items`` shadows the
+    method and the loop iterates that key's value instead of the mapping. If
+    the value is not a sequence of pairs the loop then raises ValueError.
+
+    Anything that is not a mapping yields no pairs, so the caller's
+    ``{% empty %}`` branch renders.
+    """
+    items = getattr(value, "items", None)
+    if not callable(items):
+        return []
+    try:
+        return items()
+    except TypeError:
+        return []
+
+
 @register.simple_tag
 def inline_svg(path, css_class="", label=""):
     """

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -3,6 +3,10 @@ Change log
 
 Pending
 
+* Fixed the History panel crashing when an ``application/json`` request body
+  contains a key named ``items``. Django resolves ``data.items`` with a
+  dictionary lookup before attribute lookup, so the key shadowed the mapping's
+  ``items()`` method and the template iterated its value instead.
 * Refreshed the toolbar's visual design with self-hosted Alef (panel titles)
   and Geist (body text) fonts, an updated color palette, and per-panel
   navigation icons.

--- a/tests/panels/test_history.py
+++ b/tests/panels/test_history.py
@@ -1,5 +1,6 @@
 import copy
 import html
+import json
 
 from django.test import RequestFactory, override_settings
 from django.urls import resolve, reverse
@@ -101,6 +102,33 @@ class HistoryViewsTestCase(IntegrationTestCase):
         content = toolbar.get_panel_by_id(HistoryPanel.panel_id).content
         self.assertIn("bar", content)
         self.assertIn('name="exclude_history" value="True"', content)
+
+    def test_history_panel_content_with_items_key(self):
+        """A JSON body with an ``items`` key must not break the panel.
+
+        Django resolves ``data.items`` with a dictionary lookup before it tries
+        attribute lookup, so a key named ``items`` used to shadow the method and
+        the template then iterated that key's value. See #2453.
+        """
+        for body in (
+            {"items": "a string"},
+            {"items": [1, 2, 3]},
+            {"items": {"nested": "mapping"}},
+            {"items": "shadowed", "other": "kept"},
+        ):
+            with self.subTest(body=body):
+                get_store().clear()
+                self.client.post(
+                    "/json_view/",
+                    data=json.dumps(body),
+                    content_type="application/json",
+                )
+                request_ids = list(get_store().request_ids())
+                self.assertEqual(len(request_ids), 1)
+                toolbar = DebugToolbar.fetch(request_ids[0])
+                content = toolbar.get_panel_by_id(HistoryPanel.panel_id).content
+                # The key itself is rendered, not iterated as its own mapping.
+                self.assertIn("items", content)
 
     def test_history_sidebar_invalid(self):
         response = self.client.get(reverse("djdt:history_sidebar"))

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -1,0 +1,37 @@
+from django.template import Context, Template
+from django.test import SimpleTestCase
+
+from debug_toolbar.templatetags.debug_toolbar import dict_items
+
+
+class DictItemsTestCase(SimpleTestCase):
+    def test_returns_pairs_for_a_mapping(self):
+        self.assertEqual(list(dict_items({"a": 1, "b": 2})), [("a", 1), ("b", 2)])
+
+    def test_key_named_items_does_not_shadow_the_method(self):
+        """The whole point of the filter. See #2453."""
+        self.assertEqual(
+            list(dict_items({"items": "a string"})), [("items", "a string")]
+        )
+
+    def test_non_mappings_yield_nothing(self):
+        for value in (None, "a string", [1, 2, 3], 42):
+            with self.subTest(value=value):
+                self.assertEqual(list(dict_items(value)), [])
+
+    def test_rendered_in_a_for_loop(self):
+        template = Template(
+            "{% load debug_toolbar %}"
+            "{% for key, value in data|dict_items %}{{ key }}={{ value }};"
+            "{% empty %}empty{% endfor %}"
+        )
+        cases = [
+            ({"foo": "bar"}, "foo=bar;"),
+            ({"items": "a string"}, "items=a string;"),
+            ({"items": [1, 2, 3]}, "items=[1, 2, 3];"),
+            (None, "empty"),
+            ("a string", "empty"),
+        ]
+        for data, expected in cases:
+            with self.subTest(data=data):
+                self.assertEqual(template.render(Context({"data": data})), expected)


### PR DESCRIPTION
Fixes #2453.

`history_tr.html` iterates the recorded request body with `{% for key, value in history_context.history_stats.data.items %}`. Django resolves a template variable with a dictionary lookup *before* it tries attribute lookup, so when the body is JSON containing a key named `items`, `data.items` returns that key's value instead of the mapping's `items()` method. The panel then iterates whatever that value happens to be.

The reporter described the crash. Running the current template against a few bodies, it is a bit worse than that — one case is silently wrong rather than loud:

```
{'foo': 'bar'}           -> 'foo=bar;'                  ok
{'items': 'a string'}    -> ValueError: Need 2 values to unpack in for loop; got 1.
{'items': [1, 2, 3]}     -> ValueError: Need 2 values to unpack in for loop; got 1.
{'items': {'a': 1}}      -> ValueError: Need 2 values to unpack in for loop; got 1.
{'items': [['k', 'v']]}  -> 'k=v;'                      silently renders the wrong table
```

The last one is the reason I did not just guard against the exception: with a list of pairs there is no error to catch, and the panel presents the user's data as if it were the request's key/value mapping.

This adds a `dict_items` filter and uses it at that one call site. It calls `items()` in Python, where a key named `items` does not shadow the method, so the ambiguity disappears rather than being handled. Anything that is not a mapping yields no pairs, which also tidies up a second case: `generate_stats` does `json.loads(request.body)`, so `data` can be a list or a string, and `data.items` currently fails variable resolution silently. Those now render the existing `{% empty %}` branch.

I kept this to presentation only. Normalising in `generate_stats` instead would change the shape of the stored panel data, which the store serialises and `get_stats()["data"]` exposes, so it seemed the more invasive option for the same result — happy to go that way if you would prefer it.

The other templates using `.items` iterate headers, settings and context processors — all developer-controlled keys — so I left them alone rather than widening the diff.

Tests: a unit test for the filter, and a History panel test asserting the panel renders for `items` values that are a string, a list, a nested mapping, and a mapping where `items` sits alongside another key. Five of them fail on `main` with the `ValueError` above and pass here.

`ruff check` and `ruff format --check` are clean. The full suite is unchanged: 5 errors before and after, all in `test_csp_rendering` and the example app, and identically present on an unmodified checkout — they are a gap in my local dependency install, not related to this change.