### PR TITLE
Show a single Refresh button in the History panel

### DIFF
--- a/debug_toolbar/templates/debug_toolbar/panels/history.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/history.html
@@ -1,10 +1,5 @@
 {% load i18n static %}
 
-<form method="get" action="{% url 'djdt:history_refresh' %}">
-    {{ refresh_form.as_div }}
-    <button type="button" class="refreshHistory">Refresh</button>
-</form>
-
 <table class="djdt-max-height-100">
     <thead>
         <tr>

--- a/debug_toolbar/templates/debug_toolbar/panels/history_title_bar.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/history_title_bar.html
@@ -1,5 +1,5 @@
 {% load i18n %}
 <form method="get" action="{% url 'djdt:history_refresh' %}" class="djdtHistoryRefreshForm">
     {{ refresh_form.as_div }}
-    <button class="refreshHistory">{% translate "Refresh" %}</button>
+    <button type="button" class="refreshHistory">{% translate "Refresh" %}</button>
 </form>

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -24,6 +24,10 @@ Pending
   shadow DOM.
 * Track and display processing time of application, including the toolbar's
   time, in the timer panel.
+* Fixed the History panel rendering a duplicate Refresh button below the one
+  in its title bar.
+* Fixed the History panel's Refresh button submitting its form when clicked
+  before the panel's script had loaded.
 
 7.1.1 (2026-08-14)
 ------------------


### PR DESCRIPTION
#### Description

A new Refresh button was added to the title bar, so the one in the panel body is no longer needed.

Also add an explicit type attribute to the new refresh button to prevent form submission before the panel script loads.

#### Checklist:

- [ ] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.

#### AI/LLM Usage
- [x] This PR includes code generated with the help of an AI/LLM
