### PR TITLE
Square the toolbar handle corners facing the viewport edge

### DIFF
--- a/debug_toolbar/static/debug_toolbar/css/toolbar.css
+++ b/debug_toolbar/static/debug_toolbar/css/toolbar.css
@@ -370,7 +370,7 @@
     cursor: move;
     opacity: 0.85;
     background-color: var(--djdt-accent-color);
-    border-radius: 4px;
+    border-radius: 4px 4px 0 0;
 }
 
 #djDebug #djShowToolBarButton:hover {


### PR DESCRIPTION
#### Description

This gives the handle a more "side tab" look.

<img width="103" height="133" alt="Captura de pantalla 2026-09-01 a la(s) 6 22 30 p  m" src="https://github.com/user-attachments/assets/a13b044f-17ac-4f67-8a71-023c250e5019" />

#### Checklist:

- [ ] I have added the relevant tests for this change.
- [ ] I have added an item to the Pending section of ``docs/changes.rst``.

#### AI/LLM Usage
- [ ] This PR includes code generated with the help of an AI/LLM
