### PR TITLE
Document and test the USE_SHADOW_DOM setting

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -28,6 +28,8 @@ Pending
   in its title bar.
 * Fixed the History panel's Refresh button submitting its form when clicked
   before the panel's script had loaded.
+* Documented the ``USE_SHADOW_DOM`` setting, which was added in 7.0.0 but was
+  missing from the configuration documentation, and added test coverage for it.
 
 7.1.1 (2026-08-14)
 ------------------

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -280,6 +280,21 @@ Toolbar options
   request when it occurs. This is especially useful when using htmx
   boosting or similar JavaScript techniques.
 
+.. _USE_SHADOW_DOM:
+
+* ``USE_SHADOW_DOM``
+
+  Default: ``True``
+
+  The toolbar renders inside a shadow DOM for better isolation from the rest
+  of the page.
+
+  Set this to ``False`` to render the toolbar directly in the page instead.
+  Custom panels that rely on styles defined outside the toolbar, or on DOM
+  lookups that reach into the toolbar, do not work across a shadow root and
+  may need this. See the note under `Theming support`_ for the related change
+  to CSS variable overrides.
+
 
 Panel options
 ~~~~~~~~~~~~~

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -338,6 +338,17 @@ class DebugToolbarIntegrationTestCase(IntegrationTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "djDebug")
 
+    def test_shadow_dom_enabled_by_default(self):
+        response = self.client.get("/regular/basic/")
+        self.assertContains(response, 'id="djDebugRoot"')
+        self.assertContains(response, '<template shadowrootmode="open">')
+
+    @override_settings(DEBUG_TOOLBAR_CONFIG={"USE_SHADOW_DOM": False})
+    def test_shadow_dom_can_be_disabled(self):
+        response = self.client.get("/regular/basic/")
+        self.assertContains(response, 'id="djDebugRoot"')
+        self.assertNotContains(response, "shadowrootmode")
+
     @override_settings(DEFAULT_CHARSET="iso-8859-1")
     def test_non_utf8_charset(self):
         response = self.client.get("/regular/ASCII/")


### PR DESCRIPTION
#### Description

`USE_SHADOW_DOM` has been supported since 7.0.0 and is mentioned in that release's notes, but it never made it into `docs/configuration.rst` — it's the only key in `CONFIG_DEFAULTS` without an entry there, and it had no test coverage.

This adds the docs entry under Toolbar options, after `UPDATE_ON_FETCH`. The wording about custom panels relying on external styles or DOM lookups comes from the 7.0.0 changelog, and it points at the existing Theming support note rather than repeating the CSS variable change.

It also adds two integration tests, since the setting changes rendered output and nothing was asserting on it. I checked they aren't vacuous by flipping the default to `False` and confirming `test_shadow_dom_enabled_by_default` fails.

#### Checklist:

- [x] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.

#### AI/LLM Usage
- [x] This PR includes code generated with the help of an AI/LLM
