### PR TITLE
Shrink the toolbar panel icons to 1.1em

### DIFF
--- a/debug_toolbar/static/debug_toolbar/css/toolbar.css
+++ b/debug_toolbar/static/debug_toolbar/css/toolbar.css
@@ -306,15 +306,15 @@
 }
 
 #djDebug #djDebugToolbar li .djdt-nav-icon {
-    width: 1.4em;
-    height: 1.4em;
+    width: 1.1em;
+    height: 1.1em;
     margin-inline-end: 3px;
     vertical-align: text-bottom;
 }
 
 #djDebug #djDebugToolbar li#djdt-VersionsPanel .djdt-nav-icon {
     width: auto;
-    height: 1.4em;
+    height: 1.1em;
 }
 
 #djDebug #djDebugToolbar li > div.djdt-disabled {


### PR DESCRIPTION
#### Description

I think the icons sit better beside their labels in a smaller size, and don't draw so much attention to themselves.

| Before | After |
|---|---|
| <img width="240" height="853" alt="Captura de pantalla 2026-09-02 a la(s) 12 24 52 p  m" src="https://github.com/user-attachments/assets/06bb1339-964b-4350-b70c-b7b76d45a89b" /> | <img width="240" height="843" alt="Captura de pantalla 2026-09-02 a la(s) 12 24 47 p  m" src="https://github.com/user-attachments/assets/6837bb3d-8975-49ea-a430-c25ff6e4325c" /> |

#### Checklist:

- [ ] I have added the relevant tests for this change.
- [ ] I have added an item to the Pending section of ``docs/changes.rst``.

#### AI/LLM Usage
- [ ] This PR includes code generated with the help of an AI/LLM
